### PR TITLE
HGI-10572: add batch contact and companies for FallbackSink path

### DIFF
--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -1,6 +1,6 @@
 """HubSpot CRM batch API helpers."""
 
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import backoff
 import requests
@@ -14,7 +14,13 @@ from target_hubspot_v4.utils import (
     raise_for_status,
 )
 
-CONTACTS_BATCH_UPSERT_URL = "https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert"
+BATCH_UPSERT_URL = "https://api.hubapi.com/crm/v3/objects/{object_type}/batch/upsert"
+BATCH_UPDATE_URL = "https://api.hubapi.com/crm/v3/objects/{object_type}/batch/update"
+BATCH_CREATE_URL = "https://api.hubapi.com/crm/v3/objects/{object_type}/batch/create"
+
+BATCH_KIND_UPDATE = "update"
+BATCH_KIND_UPSERT = "upsert"
+BATCH_KIND_CREATE = "create"
 
 
 def build_trace_id(staged: dict) -> str:
@@ -23,37 +29,104 @@ def build_trace_id(staged: dict) -> str:
     return staged.get("trace_id") or state.get("externalId") or state.get("hash")
 
 
-def _last_staged_by_email(staged_records: List[dict]) -> dict:
-    """Map each lowercase email to the last staged row (last-wins dedupe)."""
-    by_email = {}
+def get_hubspot_id(staged: dict) -> Optional[str]:
+    """Return the HubSpot object id from a staged record."""
+    if staged.get("id"):
+        return str(staged["id"])
+    properties = staged.get("properties") or {}
+    if properties.get("id"):
+        return str(properties["id"])
+    return None
+
+
+def get_upsert_key(staged: dict, id_property: str) -> Optional[str]:
+    """Return the batch upsert key value from a staged record."""
+    if staged.get(id_property):
+        return staged[id_property]
+    properties = staged.get("properties") or {}
+    return properties.get(id_property)
+
+
+def _normalize_key(value: str) -> str:
+    return value.lower()
+
+
+def _last_staged_by_key(
+    staged_records: List[dict],
+    key_fn: Callable[[dict], Optional[str]],
+) -> dict:
+    """Map each normalized key to the last staged row (last-wins dedupe)."""
+    by_key = {}
     for staged in staged_records:
-        email = _get_email(staged)
-        if not email:
+        raw_key = key_fn(staged)
+        if not raw_key:
             continue
-        by_email[email.lower()] = staged
-    return by_email
+        by_key[_normalize_key(str(raw_key))] = staged
+    return by_key
 
 
-def dedupe_contacts_by_email(staged_records: List[dict]) -> List[dict]:
-    """Keep the last staged record per email for batch API requests."""
-    return list(_last_staged_by_email(staged_records).values())
+def dedupe_staged_by_key(staged_records: List[dict], id_property: str) -> List[dict]:
+    """Keep the last staged record per upsert key for batch API requests."""
+    return list(_last_staged_by_key(staged_records, lambda s: get_upsert_key(s, id_property)).values())
 
 
-def build_contact_upsert_payload(staged_records: List[dict]) -> dict:
+def dedupe_staged_by_hubspot_id(staged_records: List[dict]) -> List[dict]:
+    """Keep the last staged record per HubSpot object id."""
+    return list(_last_staged_by_key(staged_records, get_hubspot_id).values())
+
+
+def _batch_properties(staged: dict, drop_id: bool = False) -> dict:
+    properties = dict(staged["properties"])
+    if drop_id:
+        properties.pop("id", None)
+    return properties
+
+
+def build_batch_upsert_payload(staged_records: List[dict], id_property: str) -> dict:
     """Build batch/upsert payload with objectWriteTraceId on each input."""
     inputs = []
     for staged in staged_records:
-        properties = dict(staged["properties"])
-        email = properties.get("email") or staged.get("email")
-        if not email:
+        properties = _batch_properties(staged)
+        upsert_key = get_upsert_key(staged, id_property)
+        if not upsert_key:
             continue
-        properties["email"] = email
+        properties[id_property] = upsert_key
         inputs.append(
             {
                 "objectWriteTraceId": build_trace_id(staged),
-                "id": email,
-                "idProperty": "email",
+                "id": upsert_key,
+                "idProperty": id_property,
                 "properties": properties,
+            }
+        )
+    return {"inputs": inputs}
+
+
+def build_batch_update_payload(staged_records: List[dict]) -> dict:
+    """Build batch/update payload with objectWriteTraceId on each input."""
+    inputs = []
+    for staged in staged_records:
+        hubspot_id = get_hubspot_id(staged)
+        if not hubspot_id:
+            continue
+        inputs.append(
+            {
+                "objectWriteTraceId": build_trace_id(staged),
+                "id": hubspot_id,
+                "properties": _batch_properties(staged, drop_id=True),
+            }
+        )
+    return {"inputs": inputs}
+
+
+def build_batch_create_payload(staged_records: List[dict]) -> dict:
+    """Build batch/create payload with objectWriteTraceId on each input."""
+    inputs = []
+    for staged in staged_records:
+        inputs.append(
+            {
+                "objectWriteTraceId": build_trace_id(staged),
+                "properties": _batch_properties(staged, drop_id=True),
             }
         )
     return {"inputs": inputs}
@@ -67,30 +140,52 @@ def build_contact_upsert_payload(staged_records: List[dict]) -> dict:
     giveup=giveup,
     interval=10,
 )
-def _post_batch_upsert(config: dict, payload: dict):
-    """POST batch/upsert with the same retry behavior as request_push."""
+def _post_batch(config: dict, url: str, payload: dict):
+    """POST a HubSpot batch endpoint with the same retry behavior as request_push."""
     params, headers = get_params_and_headers(config, None)
-    req = requests.Request(
-        "POST", CONTACTS_BATCH_UPSERT_URL, json=payload, headers=headers, params=params
-    ).prepare()
+    req = requests.Request("POST", url, json=payload, headers=headers, params=params).prepare()
     logger.info("POST %s", req.url)
     return SESSION.send(req)
 
 
-def batch_upsert_contacts(config: dict, staged_records: List[dict]):
-    """POST contacts batch/upsert and return the raw response."""
-    payload = build_contact_upsert_payload(staged_records)
-    if not payload["inputs"]:
+def _send_batch(config: dict, url: str, payload: dict):
+    """POST a batch request and return responses that may include partial success."""
+    if not payload.get("inputs"):
         return None
 
-    resp = _post_batch_upsert(config, payload)
-
+    resp = _post_batch(config, url, payload)
     if resp.status_code in (200, 201, 207, 400, 409):
         return resp
 
     raise_etl_exceptions(resp)
     raise_for_status(resp)
     return resp
+
+
+def batch_upsert_objects(
+    config: dict,
+    object_type: str,
+    id_property: str,
+    staged_records: List[dict],
+):
+    """POST batch/upsert for a CRM object type and return the raw response."""
+    payload = build_batch_upsert_payload(staged_records, id_property)
+    url = BATCH_UPSERT_URL.format(object_type=object_type)
+    return _send_batch(config, url, payload)
+
+
+def batch_update_objects(config: dict, object_type: str, staged_records: List[dict]):
+    """POST batch/update for a CRM object type and return the raw response."""
+    payload = build_batch_update_payload(staged_records)
+    url = BATCH_UPDATE_URL.format(object_type=object_type)
+    return _send_batch(config, url, payload)
+
+
+def batch_create_objects(config: dict, object_type: str, staged_records: List[dict]):
+    """POST batch/create for a CRM object type and return the raw response."""
+    payload = build_batch_create_payload(staged_records)
+    url = BATCH_CREATE_URL.format(object_type=object_type)
+    return _send_batch(config, url, payload)
 
 
 def is_whole_batch_failure(response) -> bool:
@@ -112,55 +207,70 @@ def is_whole_batch_failure(response) -> bool:
     return True
 
 
-def parse_contact_batch_response(
-    response,
-    staged_records: List[dict],
-) -> Tuple[List[dict], List[dict]]:
-    """Map batch/upsert results and errors back to staged records for state updates."""
-    state_updates = []
-    association_followups = []
+def _collect_traced_response_maps(response):
+    """Parse batch results and errors indexed by trace id and lookup key."""
     results_by_trace = {}
     errors_by_trace = {}
-    winning_trace_ids = {
-        email: build_trace_id(staged)
-        for email, staged in _last_staged_by_email(staged_records).items()
-    }
+    errors_by_key = {}
+    if response is None or is_whole_batch_failure(response):
+        return results_by_trace, errors_by_trace, errors_by_key
 
-    if response is not None and not is_whole_batch_failure(response):
-        body = response.json()
-        for result in body.get("results") or []:
-            trace_id = result.get("objectWriteTraceId")
-            if trace_id:
-                results_by_trace[trace_id] = result
-        for error in body.get("errors") or []:
-            message = error.get("message", "Batch upsert failed")
-            for trace_id in error.get("context", {}).get("objectWriteTraceId") or []:
-                errors_by_trace[trace_id] = message
-            for email in error.get("context", {}).get("ids") or []:
-                errors_by_trace.setdefault(email.lower(), message)
+    body = response.json()
+    for result in body.get("results") or []:
+        trace_id = result.get("objectWriteTraceId")
+        if trace_id:
+            results_by_trace[trace_id] = result
+
+    for error in body.get("errors") or []:
+        message = error.get("message", "Batch request failed")
+        for trace_id in error.get("context", {}).get("objectWriteTraceId") or []:
+            errors_by_trace[trace_id] = message
+        for err_id in error.get("context", {}).get("ids") or []:
+            errors_by_key.setdefault(_normalize_key(str(err_id)), message)
+
+    return results_by_trace, errors_by_trace, errors_by_key
+
+
+def parse_batch_traced_response(
+    response,
+    staged_records: List[dict],
+    record_key_fn: Callable[[dict], Optional[str]],
+    missing_result_error: str,
+) -> Tuple[List[dict], List[dict]]:
+    """Map batch results and errors back to staged records for state updates."""
+    state_updates = []
+    association_followups = []
+    results_by_trace, errors_by_trace, errors_by_key = _collect_traced_response_maps(response)
+    winning_trace_ids = {
+        key: build_trace_id(staged)
+        for key, staged in _last_staged_by_key(staged_records, record_key_fn).items()
+    }
 
     for staged in staged_records:
         meta = dict(staged.get("state") or {})
         trace_id = build_trace_id(staged)
-        email = (_get_email(staged) or "").lower()
-        winner_trace_id = winning_trace_ids.get(email)
+        raw_key = record_key_fn(staged)
+        record_key = _normalize_key(str(raw_key)) if raw_key else ""
+        winner_trace_id = winning_trace_ids.get(record_key)
 
         if trace_id in errors_by_trace:
-            state_updates.append(
-                _error_state(meta, errors_by_trace[trace_id])
-            )
+            state_updates.append(_error_state(meta, errors_by_trace[trace_id]))
             continue
 
-        if email and winner_trace_id and trace_id != winner_trace_id:
+        if record_key and winner_trace_id and trace_id != winner_trace_id:
             winner_result = results_by_trace.get(winner_trace_id)
             if winner_result and winner_result.get("id"):
                 state_updates.append(dict(meta, id=winner_result["id"], _duplicate=True))
+                if staged.get("associations"):
+                    association_followups.append(
+                        {"id": winner_result["id"], "associations": staged["associations"]}
+                    )
                 continue
             if winner_trace_id in errors_by_trace:
                 state_updates.append(_error_state(meta, errors_by_trace[winner_trace_id]))
                 continue
             state_updates.append(
-                dict(meta, success=False, error="Duplicate email superseded in batch")
+                dict(meta, success=False, error="Duplicate batch key superseded in batch")
             )
             continue
 
@@ -173,19 +283,57 @@ def parse_contact_batch_response(
                 )
             continue
 
-        if email and email in errors_by_trace:
-            state_updates.append(_error_state(meta, errors_by_trace[email]))
+        if record_key and record_key in errors_by_key:
+            state_updates.append(_error_state(meta, errors_by_key[record_key]))
             continue
 
-        state_updates.append(
-            dict(meta, success=False, error="Missing result from batch upsert")
-        )
+        state_updates.append(dict(meta, success=False, error=missing_result_error))
 
     return state_updates, association_followups
 
 
+def parse_batch_upsert_response(
+    response,
+    staged_records: List[dict],
+    id_property: str,
+) -> Tuple[List[dict], List[dict]]:
+    """Map batch/upsert results and errors back to staged records for state updates."""
+    return parse_batch_traced_response(
+        response,
+        staged_records,
+        lambda staged: get_upsert_key(staged, id_property),
+        "Missing result from batch upsert",
+    )
+
+
+def parse_batch_update_response(
+    response,
+    staged_records: List[dict],
+) -> Tuple[List[dict], List[dict]]:
+    """Map batch/update results and errors back to staged records for state updates."""
+    return parse_batch_traced_response(
+        response,
+        staged_records,
+        get_hubspot_id,
+        "Missing result from batch update",
+    )
+
+
+def parse_batch_create_response(
+    response,
+    staged_records: List[dict],
+) -> Tuple[List[dict], List[dict]]:
+    """Map batch/create results and errors back to staged records for state updates."""
+    return parse_batch_traced_response(
+        response,
+        staged_records,
+        lambda _staged: None,
+        "Missing result from batch create",
+    )
+
+
 def staged_to_tap_record(staged: dict) -> dict:
-    """Rebuild a tap-shaped contact record from a staged batch record."""
+    """Rebuild a tap-shaped record from a staged batch record."""
     record = dict(staged["properties"])
     if staged.get("associations"):
         record["associations"] = staged["associations"]
@@ -206,10 +354,3 @@ def _errors_have_trace_ids(errors: List[dict]) -> bool:
         if error.get("context", {}).get("objectWriteTraceId"):
             return True
     return False
-
-
-def _get_email(staged: dict) -> Optional[str]:
-    if staged.get("email"):
-        return staged["email"]
-    properties = staged.get("properties") or {}
-    return properties.get("email")

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -1,0 +1,196 @@
+"""HubSpot CRM batch API helpers."""
+
+from typing import List, Optional, Tuple
+
+import backoff
+import requests
+
+from target_hubspot_v4.utils import (
+    SESSION,
+    get_params_and_headers,
+    giveup,
+    logger,
+    raise_etl_exceptions,
+    raise_for_status,
+)
+
+CONTACTS_BATCH_UPSERT_URL = "https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert"
+
+
+def build_trace_id(staged: dict) -> str:
+    """Return a unique batch trace id from externalId or record hash."""
+    state = staged.get("state") or {}
+    return staged.get("trace_id") or state.get("externalId") or state.get("hash")
+
+
+def dedupe_contacts_by_email(staged_records: List[dict]) -> List[dict]:
+    """Keep the last staged record per email for batch API requests."""
+    by_email = {}
+    for staged in staged_records:
+        email = _get_email(staged)
+        if not email:
+            continue
+        by_email[email.lower()] = staged
+    return list(by_email.values())
+
+
+def build_contact_upsert_payload(staged_records: List[dict]) -> dict:
+    """Build batch/upsert payload with objectWriteTraceId on each input."""
+    inputs = []
+    for staged in staged_records:
+        properties = dict(staged["properties"])
+        email = properties.get("email") or staged.get("email")
+        if not email:
+            continue
+        properties["email"] = email
+        inputs.append(
+            {
+                "objectWriteTraceId": build_trace_id(staged),
+                "id": email,
+                "idProperty": "email",
+                "properties": properties,
+            }
+        )
+    return {"inputs": inputs}
+
+
+@backoff.on_exception(
+    backoff.constant,
+    (requests.exceptions.RequestException, requests.exceptions.HTTPError),
+    max_tries=5,
+    jitter=None,
+    giveup=giveup,
+    interval=10,
+)
+def _post_batch_upsert(config: dict, payload: dict):
+    """POST batch/upsert with the same retry behavior as request_push."""
+    params, headers = get_params_and_headers(config, None)
+    req = requests.Request(
+        "POST", CONTACTS_BATCH_UPSERT_URL, json=payload, headers=headers, params=params
+    ).prepare()
+    logger.info("POST %s", req.url)
+    return SESSION.send(req)
+
+
+def batch_upsert_contacts(config: dict, staged_records: List[dict]):
+    """POST contacts batch/upsert and return the raw response."""
+    payload = build_contact_upsert_payload(staged_records)
+    if not payload["inputs"]:
+        return None
+
+    resp = _post_batch_upsert(config, payload)
+
+    if resp.status_code in (200, 201, 207, 400, 409):
+        return resp
+
+    raise_etl_exceptions(resp)
+    raise_for_status(resp)
+    return resp
+
+
+def is_whole_batch_failure(response) -> bool:
+    """Return True when the batch response has no per-record results or trace errors."""
+    if response is None:
+        return True
+    if response.status_code in (200, 201, 207):
+        return False
+    if response.status_code != 400:
+        return True
+    try:
+        body = response.json()
+    except (ValueError, TypeError):
+        return True
+    if body.get("results"):
+        return False
+    if _errors_have_trace_ids(body.get("errors") or []):
+        return False
+    return True
+
+
+def parse_contact_batch_response(
+    response,
+    staged_records: List[dict],
+) -> Tuple[List[dict], List[dict]]:
+    """Map batch/upsert results and errors back to staged records for state updates."""
+    state_updates = []
+    association_followups = []
+    results_by_trace = {}
+    errors_by_trace = {}
+    results_by_email = {}
+
+    if response is not None and not is_whole_batch_failure(response):
+        body = response.json()
+        for result in body.get("results") or []:
+            trace_id = result.get("objectWriteTraceId")
+            if trace_id:
+                results_by_trace[trace_id] = result
+            email = ((result.get("properties") or {}).get("email") or "").lower()
+            if email:
+                results_by_email[email] = result
+        for error in body.get("errors") or []:
+            message = error.get("message", "Batch upsert failed")
+            for trace_id in error.get("context", {}).get("objectWriteTraceId") or []:
+                errors_by_trace[trace_id] = message
+            for email in error.get("context", {}).get("ids") or []:
+                errors_by_trace.setdefault(email.lower(), message)
+
+    for staged in staged_records:
+        meta = dict(staged.get("state") or {})
+        trace_id = build_trace_id(staged)
+        email = (_get_email(staged) or "").lower()
+
+        if trace_id in errors_by_trace:
+            state_updates.append(
+                _error_state(meta, errors_by_trace[trace_id])
+            )
+            continue
+
+        result = results_by_trace.get(trace_id) or results_by_email.get(email)
+        if result and result.get("id"):
+            state_updates.append(dict(meta, success=True, id=result["id"]))
+            if staged.get("associations"):
+                association_followups.append(
+                    {"id": result["id"], "associations": staged["associations"]}
+                )
+            continue
+
+        if email and email in errors_by_trace:
+            state_updates.append(_error_state(meta, errors_by_trace[email]))
+            continue
+
+        state_updates.append(
+            dict(meta, success=False, error="Missing result from batch upsert")
+        )
+
+    return state_updates, association_followups
+
+
+def staged_to_tap_record(staged: dict) -> dict:
+    """Rebuild a tap-shaped contact record from a staged batch record."""
+    record = dict(staged["properties"])
+    if staged.get("associations"):
+        record["associations"] = staged["associations"]
+    return record
+
+
+def _error_state(meta: dict, message: str) -> dict:
+    return dict(
+        meta,
+        success=None,
+        error=message,
+        hg_error_class="InvalidPayloadError",
+    )
+
+
+def _errors_have_trace_ids(errors: List[dict]) -> bool:
+    for error in errors:
+        if error.get("context", {}).get("objectWriteTraceId"):
+            return True
+    return False
+
+
+def _get_email(staged: dict) -> Optional[str]:
+    if staged.get("email"):
+        return staged["email"]
+    properties = staged.get("properties") or {}
+    return properties.get("email")

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -194,7 +194,7 @@ def is_whole_batch_failure(response) -> bool:
         return True
     if response.status_code in (200, 201, 207):
         return False
-    if response.status_code != 400:
+    if response.status_code not in (400, 409):
         return True
     try:
         body = response.json()

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -260,7 +260,7 @@ def parse_batch_traced_response(
         if record_key and winner_trace_id and trace_id != winner_trace_id:
             winner_result = results_by_trace.get(winner_trace_id)
             if winner_result and winner_result.get("id"):
-                state_updates.append(dict(meta, id=winner_result["id"], _duplicate=True))
+                state_updates.append(dict(meta, success=True, id=winner_result["id"], _duplicate=True))
                 if staged.get("associations"):
                     association_followups.append(
                         {"id": winner_result["id"], "associations": staged["associations"]}

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -343,7 +343,7 @@ def staged_to_tap_record(staged: dict) -> dict:
 def _error_state(meta: dict, message: str) -> dict:
     return dict(
         meta,
-        success=None,
+        success=False,
         error=message,
         hg_error_class="InvalidPayloadError",
     )

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -24,9 +24,9 @@ BATCH_KIND_CREATE = "create"
 
 
 def build_trace_id(staged: dict) -> str:
-    """Return a unique batch trace id from externalId or record hash."""
+    """Return a unique batch trace id from the staged record hash."""
     state = staged.get("state") or {}
-    return staged.get("trace_id") or state.get("externalId") or state.get("hash")
+    return staged.get("trace_id") or state.get("hash")
 
 
 def get_hubspot_id(staged: dict) -> Optional[str]:

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -23,15 +23,20 @@ def build_trace_id(staged: dict) -> str:
     return staged.get("trace_id") or state.get("externalId") or state.get("hash")
 
 
-def dedupe_contacts_by_email(staged_records: List[dict]) -> List[dict]:
-    """Keep the last staged record per email for batch API requests."""
+def _last_staged_by_email(staged_records: List[dict]) -> dict:
+    """Map each lowercase email to the last staged row (last-wins dedupe)."""
     by_email = {}
     for staged in staged_records:
         email = _get_email(staged)
         if not email:
             continue
         by_email[email.lower()] = staged
-    return list(by_email.values())
+    return by_email
+
+
+def dedupe_contacts_by_email(staged_records: List[dict]) -> List[dict]:
+    """Keep the last staged record per email for batch API requests."""
+    return list(_last_staged_by_email(staged_records).values())
 
 
 def build_contact_upsert_payload(staged_records: List[dict]) -> dict:
@@ -116,7 +121,10 @@ def parse_contact_batch_response(
     association_followups = []
     results_by_trace = {}
     errors_by_trace = {}
-    results_by_email = {}
+    winning_trace_ids = {
+        email: build_trace_id(staged)
+        for email, staged in _last_staged_by_email(staged_records).items()
+    }
 
     if response is not None and not is_whole_batch_failure(response):
         body = response.json()
@@ -124,9 +132,6 @@ def parse_contact_batch_response(
             trace_id = result.get("objectWriteTraceId")
             if trace_id:
                 results_by_trace[trace_id] = result
-            email = ((result.get("properties") or {}).get("email") or "").lower()
-            if email:
-                results_by_email[email] = result
         for error in body.get("errors") or []:
             message = error.get("message", "Batch upsert failed")
             for trace_id in error.get("context", {}).get("objectWriteTraceId") or []:
@@ -138,6 +143,7 @@ def parse_contact_batch_response(
         meta = dict(staged.get("state") or {})
         trace_id = build_trace_id(staged)
         email = (_get_email(staged) or "").lower()
+        winner_trace_id = winning_trace_ids.get(email)
 
         if trace_id in errors_by_trace:
             state_updates.append(
@@ -145,7 +151,20 @@ def parse_contact_batch_response(
             )
             continue
 
-        result = results_by_trace.get(trace_id) or results_by_email.get(email)
+        if email and winner_trace_id and trace_id != winner_trace_id:
+            winner_result = results_by_trace.get(winner_trace_id)
+            if winner_result and winner_result.get("id"):
+                state_updates.append(dict(meta, id=winner_result["id"], _duplicate=True))
+                continue
+            if winner_trace_id in errors_by_trace:
+                state_updates.append(_error_state(meta, errors_by_trace[winner_trace_id]))
+                continue
+            state_updates.append(
+                dict(meta, success=False, error="Duplicate email superseded in batch")
+            )
+            continue
+
+        result = results_by_trace.get(trace_id)
         if result and result.get("id"):
             state_updates.append(dict(meta, success=True, id=result["id"]))
             if staged.get("associations"):

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -303,13 +303,26 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         context.setdefault("records", []).append(staged)
 
+    def _get_bookmark_state_by_hash(self, record_hash: str) -> Optional[dict]:
+        """Return the latest bookmark state for a record hash, success or failure."""
+        states = self.latest_state["bookmarks"][self.name]
+        for state in reversed(states):
+            if state.get("hash") == record_hash:
+                return dict(state)
+        return None
+
     def _apply_flush_duplicate_states(self, context: dict) -> None:
         """Mark in-flush duplicate rows using the winner state after batch writes."""
         for dup_state in context.get("flush_duplicate_states") or []:
-            existing_state = self.get_existing_state(dup_state["hash"])
-            if not existing_state:
-                continue
-            state = dict(existing_state)
+            winner_state = self._get_bookmark_state_by_hash(dup_state["hash"])
+            if winner_state:
+                state = dict(winner_state)
+            else:
+                state = dict(
+                    dup_state,
+                    success=False,
+                    error="Duplicate of batch record with no persisted state",
+                )
             external_id = dup_state.get("externalId")
             if external_id:
                 state["externalId"] = external_id

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -194,9 +194,10 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                         for followup in result.get("association_followups", []):
                             FallbackSink.put_associations(self, followup["id"], followup["associations"])
                         for state in result.get("state_updates", []):
+                            is_duplicate = state.pop("_duplicate", False)
                             if state.get("success"):
                                 self.logger.info("%s processed id: %s", self.name, state.get("id"))
-                            self.update_state(state)
+                            self.update_state(state, is_duplicate=is_duplicate)
         finally:
             for item in context.get("single_records") or []:
                 self.write_single_tap_record(item["record"], item.get("external_id"), context)

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -91,6 +91,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         yield {
             "records": deduped,
+            "staged_records": staged_records,
             "request": lambda records: batch_upsert_objects(config, object_type, id_property, records),
             "parse": lambda response, records: parse_batch_upsert_response(response, records, id_property),
         }
@@ -177,20 +178,23 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
     def _process_staged_batch(self, staged_records: List[dict], context: dict) -> None:
         """Run each batch request group and fall back to single-record writes on failure."""
         for batch_spec in self.iter_batch_requests(staged_records):
-            records = batch_spec["records"]
-            if not records:
+            api_records = batch_spec["records"]
+            parse_records = batch_spec["staged_records"]
+            if not api_records:
                 continue
             try:
-                response = batch_spec["request"](records)
+                response = batch_spec["request"](api_records)
             except Exception:
                 self.logger.exception("Batch request failed for %s", self.name)
-                self._fallback_batch_records(records, context)
+                self._fallback_batch_records(parse_records, context)
             else:
                 if is_whole_batch_failure(response):
-                    self._fallback_batch_records(records, context)
+                    self._fallback_batch_records(parse_records, context)
                 else:
                     self._apply_batch_result(
-                        self._normalize_batch_parse_result(batch_spec["parse"](response, records))
+                        self._normalize_batch_parse_result(
+                            batch_spec["parse"](response, parse_records)
+                        )
                     )
 
     def process_record(self, record: dict, context: dict) -> None:

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -7,11 +7,17 @@ from hotglue_etl_exceptions import InvalidCredentialsError, InvalidPayloadError
 from hotglue_singer_sdk.target_sdk.client import HotglueBatchSink
 
 from target_hubspot_v4.batch import (
+    BATCH_KIND_CREATE,
     BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
+    batch_create_objects,
+    batch_update_objects,
     batch_upsert_objects,
+    dedupe_staged_by_hubspot_id,
     dedupe_staged_by_key,
     is_whole_batch_failure,
+    parse_batch_create_response,
+    parse_batch_update_response,
     parse_batch_upsert_response,
     staged_to_tap_record,
 )
@@ -40,6 +46,11 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         return self.stream_name
 
     @property
+    def supports_batch_create(self) -> bool:
+        """Return True when rows without an upsert key may use batch/create."""
+        return False
+
+    @property
     @abstractmethod
     def batch_id_property(self) -> str:
         """HubSpot idProperty used for batch/upsert (first lookup field)."""
@@ -60,6 +71,22 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         return record, associations
 
+    def _stage_batch_record(
+        self,
+        batch_kind: str,
+        properties: dict,
+        associations,
+        **extra,
+    ) -> dict:
+        """Build a staged batch record with the shared shape."""
+        staged = {
+            "properties": properties,
+            "associations": associations,
+            "batch_kind": batch_kind,
+        }
+        staged.update(extra)
+        return staged
+
     def _resolve_lookup_id(self, properties: dict) -> Optional[str]:
         """Return a HubSpot id when lookup fields match exactly one object."""
         if not self.lookup_fields:
@@ -74,43 +101,83 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         return None
 
     def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
-        """Stage a record for batch upsert when it has the configured upsert key."""
+        """Stage a record for batch update, upsert, create, or single-record fallback."""
         properties, associations = self.parse_fallback_properties(record)
+        hubspot_id = properties.get("id")
+
+        if hubspot_id:
+            return self._stage_batch_record(
+                BATCH_KIND_UPDATE,
+                properties,
+                associations,
+                id=str(hubspot_id),
+            )
+
         properties.pop("id", None)
-        id_property = self.batch_id_property
-        upsert_key = properties.get(id_property)
-        if not upsert_key:
-            return None
+        if self.lookup_fields:
+            found_id = self._resolve_lookup_id(properties)
+            if found_id:
+                return self._stage_batch_record(
+                    BATCH_KIND_UPDATE,
+                    properties,
+                    associations,
+                    id=found_id,
+                )
 
-        found_id = self._resolve_lookup_id(properties)
-        if found_id:
-            return {
-                "properties": properties,
-                "associations": associations,
-                "batch_kind": BATCH_KIND_UPDATE,
-                "id": found_id,
-            }
+        upsert_key = properties.get(self.batch_id_property)
+        if upsert_key:
+            return self._stage_batch_record(
+                BATCH_KIND_UPSERT,
+                properties,
+                associations,
+                **{self.batch_id_property: upsert_key},
+            )
 
-        return {
-            "properties": properties,
-            "associations": associations,
-            "batch_kind": BATCH_KIND_UPSERT,
-            id_property: upsert_key,
-        }
+        if self.supports_batch_create:
+            return self._stage_batch_record(BATCH_KIND_CREATE, properties, associations)
+        return None
 
     def iter_batch_requests(self, staged_records: List[dict]) -> Iterator[dict]:
-        """Yield batch request specs for a flush of staged records."""
-        deduped = dedupe_staged_by_key(staged_records, self.batch_id_property)
+        """Route staged records to batch/update, batch/upsert, and batch/create."""
         config = self._target._config
         object_type = self.name
         id_property = self.batch_id_property
 
-        yield {
-            "records": deduped,
-            "staged_records": staged_records,
-            "request": lambda records: batch_upsert_objects(config, object_type, id_property, records),
-            "parse": lambda response, records: parse_batch_upsert_response(response, records, id_property),
+        update_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPDATE]
+        upsert_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPSERT]
+        create_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_CREATE]
+
+        by_kind = {
+            BATCH_KIND_UPDATE: dedupe_staged_by_hubspot_id(update_staged),
+            BATCH_KIND_UPSERT: dedupe_staged_by_key(upsert_staged, id_property),
+            BATCH_KIND_CREATE: create_staged,
         }
+
+        if by_kind[BATCH_KIND_UPDATE]:
+            yield {
+                "records": by_kind[BATCH_KIND_UPDATE],
+                "staged_records": update_staged,
+                "request": lambda records: batch_update_objects(config, object_type, records),
+                "parse": parse_batch_update_response,
+            }
+        if by_kind[BATCH_KIND_UPSERT]:
+            yield {
+                "records": by_kind[BATCH_KIND_UPSERT],
+                "staged_records": upsert_staged,
+                "request": lambda records: batch_upsert_objects(
+                    config, object_type, id_property, records
+                ),
+                "parse": lambda response, records: parse_batch_upsert_response(
+                    response, records, id_property
+                ),
+            }
+        if by_kind[BATCH_KIND_CREATE]:
+            yield {
+                "records": by_kind[BATCH_KIND_CREATE],
+                "staged_records": create_staged,
+                "request": lambda records: batch_create_objects(config, object_type, records),
+                "parse": parse_batch_create_response,
+            }
 
     def make_batch_request(self, records: List[dict]):
         """Satisfy HotglueBatchSink ABC; batch flushing uses iter_batch_requests instead."""

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -1,12 +1,19 @@
 """HubSpot batch sink base class."""
 
 from abc import abstractmethod
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from hotglue_etl_exceptions import InvalidCredentialsError, InvalidPayloadError
 from hotglue_singer_sdk.target_sdk.client import HotglueBatchSink
 
-from target_hubspot_v4.batch import is_whole_batch_failure, staged_to_tap_record
+from target_hubspot_v4.batch import (
+    BATCH_KIND_UPSERT,
+    batch_upsert_objects,
+    dedupe_staged_by_key,
+    is_whole_batch_failure,
+    parse_batch_upsert_response,
+    staged_to_tap_record,
+)
 from target_hubspot_v4.client import HubspotSink
 from target_hubspot_v4.sinks import FallbackSink
 
@@ -31,6 +38,12 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
     def name(self):
         return self.stream_name
 
+    @property
+    @abstractmethod
+    def batch_id_property(self) -> str:
+        """HubSpot idProperty used for batch/upsert (first lookup field)."""
+        raise NotImplementedError()
+
     def preprocess_record(self, record: dict, context: dict):
         return record
 
@@ -46,23 +59,47 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         return record, associations
 
-    @abstractmethod
     def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
-        raise NotImplementedError()
+        """Stage a record for batch upsert when it has the configured upsert key."""
+        properties, associations = self.parse_fallback_properties(record)
+        properties.pop("id", None)
+        id_property = self.batch_id_property
+        upsert_key = properties.get(id_property)
+        if not upsert_key:
+            return None
 
-    @abstractmethod
+        if self.lookup_fields:
+            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
+            if existing_objects and len(existing_objects) > 1:
+                raise InvalidPayloadError(
+                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
+                )
+
+        return {
+            "properties": properties,
+            "associations": associations,
+            "batch_kind": BATCH_KIND_UPSERT,
+            id_property: upsert_key,
+        }
+
+    def iter_batch_requests(self, staged_records: List[dict]) -> Iterator[dict]:
+        """Yield batch request specs for a flush of staged records."""
+        deduped = dedupe_staged_by_key(staged_records, self.batch_id_property)
+        config = self._target._config
+        object_type = self.name
+        id_property = self.batch_id_property
+
+        yield {
+            "records": deduped,
+            "request": lambda records: batch_upsert_objects(config, object_type, id_property, records),
+            "parse": lambda response, records: parse_batch_upsert_response(response, records, id_property),
+        }
+
     def make_batch_request(self, records: List[dict]):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def parse_batch_response(self, response, staged_records: List[dict]) -> dict:
-        raise NotImplementedError()
-
-    def get_tap_record_email(self, record: dict) -> Optional[str]:
-        """Return the contact email from a tap-shaped record, if present."""
-        properties = record.get("properties") or record
-        email = properties.get("email")
-        return email if email else None
+        """Satisfy HotglueBatchSink ABC; batch flushing uses iter_batch_requests instead."""
+        for batch_spec in self.iter_batch_requests(records):
+            return batch_spec["request"](batch_spec["records"])
+        return None
 
     def _error_classification_metadata(self, exc: Exception) -> dict:
         if isinstance(exc, (InvalidCredentialsError, InvalidPayloadError)):
@@ -102,6 +139,16 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             payload["associations"] = staged["associations"]
         return self.build_record_hash(payload)
 
+    def _apply_batch_result(self, result: dict) -> None:
+        """Apply parsed batch state updates and association followups."""
+        for state in result.get("state_updates", []):
+            is_duplicate = state.pop("_duplicate", False)
+            if state.get("success"):
+                self.logger.info("%s processed id: %s", self.name, state.get("id"))
+            self.update_state(state, is_duplicate=is_duplicate)
+        for followup in result.get("association_followups", []):
+            FallbackSink.put_associations(self, followup["id"], followup["associations"])
+
     def _fallback_batch_records(self, staged_records: List[dict], context: dict) -> None:
         """Write each staged batch record through single-record FallbackSink."""
         self.logger.warning(
@@ -118,6 +165,34 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         tap_record = staged_to_tap_record(staged)
         self.write_single_tap_record(tap_record, external_id, context)
 
+    def _normalize_batch_parse_result(self, parsed) -> dict:
+        if isinstance(parsed, tuple):
+            state_updates, association_followups = parsed
+            return {
+                "state_updates": state_updates,
+                "association_followups": association_followups,
+            }
+        return parsed
+
+    def _process_staged_batch(self, staged_records: List[dict], context: dict) -> None:
+        """Run each batch request group and fall back to single-record writes on failure."""
+        for batch_spec in self.iter_batch_requests(staged_records):
+            records = batch_spec["records"]
+            if not records:
+                continue
+            try:
+                response = batch_spec["request"](records)
+            except Exception:
+                self.logger.exception("Batch request failed for %s", self.name)
+                self._fallback_batch_records(records, context)
+            else:
+                if is_whole_batch_failure(response):
+                    self._fallback_batch_records(records, context)
+                else:
+                    self._apply_batch_result(
+                        self._normalize_batch_parse_result(batch_spec["parse"](response, records))
+                    )
+
     def process_record(self, record: dict, context: dict) -> None:
         """Stage a record for batch write, or queue it for single-record FallbackSink."""
         if not self.latest_state:
@@ -132,16 +207,12 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             external_id = record.pop(external_id_key, None) or record.pop(external_id_key.lower(), None)
 
         tap_record = dict(record)
-        # Batch upsert needs an email idProperty; no-email records use FallbackSink instead.
-        if not self.get_tap_record_email(tap_record):
-            context.setdefault("single_records", []).append(
-                {"record": tap_record, "external_id": external_id}
-            )
-            return
-
         try:
             staged = self.prepare_staged_record(tap_record, context)
             if not staged:
+                context.setdefault("single_records", []).append(
+                    {"record": tap_record, "external_id": external_id}
+                )
                 return
         except Exception as exc:
             self.logger.exception("Preprocess record error %s", exc)
@@ -164,7 +235,6 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             self.update_state(existing_state, is_duplicate=True, record=staged["properties"])
             return
 
-        # objectWriteTraceId maps HubSpot 207 results/errors back to this staged row.
         trace_id = external_id or record_hash
         staged["trace_id"] = trace_id
         staged["state"] = {"hash": record_hash}
@@ -181,23 +251,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         raw_records = context.get("records") or []
         try:
             if raw_records:
-                try:
-                    response = self.make_batch_request(raw_records)
-                except Exception:
-                    self.logger.exception("Batch request failed for %s", self.name)
-                    self._fallback_batch_records(raw_records, context)
-                else:
-                    if is_whole_batch_failure(response):
-                        self._fallback_batch_records(raw_records, context)
-                    else:
-                        result = self.parse_batch_response(response, raw_records)
-                        for followup in result.get("association_followups", []):
-                            FallbackSink.put_associations(self, followup["id"], followup["associations"])
-                        for state in result.get("state_updates", []):
-                            is_duplicate = state.pop("_duplicate", False)
-                            if state.get("success"):
-                                self.logger.info("%s processed id: %s", self.name, state.get("id"))
-                            self.update_state(state, is_duplicate=is_duplicate)
+                self._process_staged_batch(raw_records, context)
         finally:
             for item in context.get("single_records") or []:
                 self.write_single_tap_record(item["record"], item.get("external_id"), context)

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -51,6 +51,11 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         return False
 
     @property
+    def skip_staging_lookup(self) -> bool:
+        """Return True to skip pre-batch search; batch/upsert handles create/update."""
+        return False
+
+    @property
     @abstractmethod
     def batch_id_property(self) -> str:
         """HubSpot idProperty used for batch/upsert (first lookup field)."""
@@ -114,7 +119,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             )
 
         properties.pop("id", None)
-        if self.lookup_fields:
+        if self.lookup_fields and not self.skip_staging_lookup:
             found_id = self._resolve_lookup_id(properties)
             if found_id:
                 return self._stage_batch_record(

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -7,6 +7,7 @@ from hotglue_etl_exceptions import InvalidCredentialsError, InvalidPayloadError
 from hotglue_singer_sdk.target_sdk.client import HotglueBatchSink
 
 from target_hubspot_v4.batch import (
+    BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
     batch_upsert_objects,
     dedupe_staged_by_key,
@@ -59,6 +60,19 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         return record, associations
 
+    def _resolve_lookup_id(self, properties: dict) -> Optional[str]:
+        """Return a HubSpot id when lookup fields match exactly one object."""
+        if not self.lookup_fields:
+            return None
+        existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
+        if existing_objects and len(existing_objects) > 1:
+            raise InvalidPayloadError(
+                f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
+            )
+        if existing_objects and len(existing_objects) == 1:
+            return str(existing_objects[0]["id"])
+        return None
+
     def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
         """Stage a record for batch upsert when it has the configured upsert key."""
         properties, associations = self.parse_fallback_properties(record)
@@ -68,12 +82,14 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         if not upsert_key:
             return None
 
-        if self.lookup_fields:
-            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
-            if existing_objects and len(existing_objects) > 1:
-                raise InvalidPayloadError(
-                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
-                )
+        found_id = self._resolve_lookup_id(properties)
+        if found_id:
+            return {
+                "properties": properties,
+                "associations": associations,
+                "batch_kind": BATCH_KIND_UPDATE,
+                "id": found_id,
+            }
 
         return {
             "properties": properties,

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -191,11 +191,15 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                 if is_whole_batch_failure(response):
                     self._fallback_batch_records(parse_records, context)
                 else:
-                    self._apply_batch_result(
-                        self._normalize_batch_parse_result(
-                            batch_spec["parse"](response, parse_records)
+                    try:
+                        self._apply_batch_result(
+                            self._normalize_batch_parse_result(
+                                batch_spec["parse"](response, parse_records)
+                            )
                         )
-                    )
+                    except Exception:
+                        self.logger.exception("Batch result handling failed for %s", self.name)
+                        self._fallback_batch_records(parse_records, context)
 
     def process_record(self, record: dict, context: dict) -> None:
         """Stage a record for batch write, or queue it for single-record FallbackSink."""

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -140,13 +140,36 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             payload["associations"] = staged["associations"]
         return self.build_record_hash(payload)
 
-    def _apply_batch_result(self, result: dict) -> None:
+    def _staged_record_hash(self, staged: dict) -> Optional[str]:
+        """Return the content hash for a staged batch record, if present."""
+        return (staged.get("state") or {}).get("hash")
+
+    def _unapplied_staged_records(self, staged_records: List[dict], applied_hashes: set) -> List[dict]:
+        """Return staged rows whose batch state updates were not applied."""
+        return [
+            staged
+            for staged in staged_records
+            if self._staged_record_hash(staged) not in applied_hashes
+        ]
+
+    def _apply_batch_result(self, result: dict) -> set:
         """Apply parsed batch state updates and association followups."""
+        applied_hashes = set()
         for state in result.get("state_updates", []):
             is_duplicate = state.pop("_duplicate", False)
-            if state.get("success"):
-                self.logger.info("%s processed id: %s", self.name, state.get("id"))
-            self.update_state(state, is_duplicate=is_duplicate)
+            record_hash = state.get("hash")
+            try:
+                if state.get("success"):
+                    self.logger.info("%s processed id: %s", self.name, state.get("id"))
+                self.update_state(state, is_duplicate=is_duplicate)
+                if record_hash:
+                    applied_hashes.add(record_hash)
+            except Exception:
+                self.logger.exception(
+                    "Batch state update failed for %s hash %s",
+                    self.name,
+                    record_hash,
+                )
         for followup in result.get("association_followups", []):
             try:
                 FallbackSink.put_associations(self, followup["id"], followup["associations"])
@@ -156,6 +179,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                     self.name,
                     followup.get("id"),
                 )
+        return applied_hashes
 
     def _fallback_batch_records(self, staged_records: List[dict], context: dict) -> None:
         """Write each staged batch record through single-record FallbackSink."""
@@ -199,14 +223,22 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                     self._fallback_batch_records(parse_records, context)
                 else:
                     try:
-                        self._apply_batch_result(
-                            self._normalize_batch_parse_result(
-                                batch_spec["parse"](response, parse_records)
-                            )
+                        parsed = self._normalize_batch_parse_result(
+                            batch_spec["parse"](response, parse_records)
                         )
                     except Exception:
-                        self.logger.exception("Batch result handling failed for %s", self.name)
+                        self.logger.exception("Batch result parsing failed for %s", self.name)
                         self._fallback_batch_records(parse_records, context)
+                    else:
+                        applied_hashes = self._apply_batch_result(parsed)
+                        unapplied = self._unapplied_staged_records(parse_records, applied_hashes)
+                        if unapplied:
+                            self.logger.warning(
+                                "Batch apply incomplete for %s; falling back on %d records",
+                                self.name,
+                                len(unapplied),
+                            )
+                            self._fallback_batch_records(unapplied, context)
 
     def process_record(self, record: dict, context: dict) -> None:
         """Stage a record for batch write, or queue it for single-record FallbackSink."""

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -1,0 +1,204 @@
+"""HubSpot batch sink base class."""
+
+from abc import abstractmethod
+from typing import List, Optional
+
+from hotglue_etl_exceptions import InvalidCredentialsError, InvalidPayloadError
+from hotglue_singer_sdk.target_sdk.client import HotglueBatchSink
+
+from target_hubspot_v4.batch import is_whole_batch_failure, staged_to_tap_record
+from target_hubspot_v4.client import HubspotSink
+from target_hubspot_v4.sinks import FallbackSink
+
+HUBSPOT_BATCH_LIMIT = 100
+
+
+class HubspotBatchSink(HubspotSink, HotglueBatchSink):
+    """Base batch sink for fallback HubSpot object streams."""
+
+    max_size = HUBSPOT_BATCH_LIMIT
+
+    @property
+    def current_size(self):
+        """Return the number of records buffered for the current batch."""
+        return self._batch_records_read
+
+    @property
+    def unified_schema(self):
+        return None
+
+    @property
+    def name(self):
+        return self.stream_name
+
+    def preprocess_record(self, record: dict, context: dict):
+        return record
+
+    def parse_fallback_properties(self, record: dict):
+        """Normalize a fallback tap record into flat properties and associations."""
+        record = dict(record)
+        associations = record.pop("associations", None)
+
+        if record.get("properties"):
+            record = record["properties"]
+        for key, value in record.items():
+            record[key] = self.parse_objs(value)
+
+        return record, associations
+
+    @abstractmethod
+    def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def make_batch_request(self, records: List[dict]):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def parse_batch_response(self, response, staged_records: List[dict]) -> dict:
+        raise NotImplementedError()
+
+    def get_tap_record_email(self, record: dict) -> Optional[str]:
+        """Return the contact email from a tap-shaped record, if present."""
+        properties = record.get("properties") or record
+        email = properties.get("email")
+        return email if email else None
+
+    def _error_classification_metadata(self, exc: Exception) -> dict:
+        if isinstance(exc, (InvalidCredentialsError, InvalidPayloadError)):
+            return {"hg_error_class": exc.__class__.__name__}
+        return {}
+
+    def _single_record_sink(self) -> FallbackSink:
+        """Return a FallbackSink sharing this sink's state for single-record writes."""
+        sink = FallbackSink(self._target, self.stream_name, self.schema, self.key_properties)
+        sink.latest_state = self.latest_state
+        sink.processed_hashes = self.processed_hashes
+        return sink
+
+    def _sync_single_sink_state(self, sink: FallbackSink) -> None:
+        """Copy state back from a FallbackSink used for single-record writes."""
+        self.processed_hashes = sink.processed_hashes
+        self.latest_state = sink.latest_state
+
+    def write_single_tap_record(
+        self,
+        tap_record: dict,
+        external_id: Optional[str],
+        context: dict,
+    ) -> None:
+        """Write one record through FallbackSink lookup and upsert logic."""
+        record = dict(tap_record)
+        if external_id:
+            record[self._target.EXTERNAL_ID_KEY] = external_id
+        sink = self._single_record_sink()
+        FallbackSink.process_record(sink, record, context)
+        self._sync_single_sink_state(sink)
+
+    def build_staged_record_hash(self, staged: dict) -> str:
+        """Hash a staged record the same way FallbackSink hashes preprocessed payloads."""
+        payload = {"properties": staged["properties"]}
+        if staged.get("associations"):
+            payload["associations"] = staged["associations"]
+        return self.build_record_hash(payload)
+
+    def _fallback_batch_records(self, staged_records: List[dict], context: dict) -> None:
+        """Write each staged batch record through single-record FallbackSink."""
+        self.logger.warning(
+            "Batch request for %s failed entirely; falling back to single-record writes",
+            self.name,
+        )
+        for staged in staged_records:
+            self.write_single_staged_record(staged, context)
+
+    def write_single_staged_record(self, staged: dict, context: dict) -> None:
+        """Fallback one staged batch record to single-record FallbackSink writes."""
+        meta = staged.get("state") or {}
+        external_id = meta.get("externalId")
+        tap_record = staged_to_tap_record(staged)
+        self.write_single_tap_record(tap_record, external_id, context)
+
+    def process_record(self, record: dict, context: dict) -> None:
+        """Stage a record for batch write, or queue it for single-record FallbackSink."""
+        if not self.latest_state:
+            self.init_state()
+
+        external_id_key = self._target.EXTERNAL_ID_KEY
+        external_id = None
+
+        if self.name not in self.allows_externalid and (
+            record.get(external_id_key) or record.get(external_id_key.lower())
+        ):
+            external_id = record.pop(external_id_key, None) or record.pop(external_id_key.lower(), None)
+
+        tap_record = dict(record)
+        # Batch upsert needs an email idProperty; no-email records use FallbackSink instead.
+        if not self.get_tap_record_email(tap_record):
+            context.setdefault("single_records", []).append(
+                {"record": tap_record, "external_id": external_id}
+            )
+            return
+
+        try:
+            staged = self.prepare_staged_record(tap_record, context)
+            if not staged:
+                return
+        except Exception as exc:
+            self.logger.exception("Preprocess record error %s", exc)
+            state_updates = {"error": str(exc)}
+            state_updates.update(self._error_classification_metadata(exc))
+            success = None if isinstance(exc, InvalidPayloadError) else False
+            error_state = dict(success=success, **state_updates)
+            if external_id:
+                error_state["externalId"] = external_id
+            self.update_state(error_state, record=tap_record)
+            return
+
+        record_hash = self.build_staged_record_hash(staged)
+        if record_hash in self.processed_hashes:
+            self.logger.info("Record of type %s already exists with hash: %s", self.name, record_hash)
+            return
+
+        existing_state = self.get_existing_state(record_hash)
+        if existing_state:
+            self.update_state(existing_state, is_duplicate=True, record=staged["properties"])
+            return
+
+        # objectWriteTraceId maps HubSpot 207 results/errors back to this staged row.
+        trace_id = external_id or record_hash
+        staged["trace_id"] = trace_id
+        staged["state"] = {"hash": record_hash}
+        if external_id:
+            staged["state"]["externalId"] = external_id
+
+        context.setdefault("records", []).append(staged)
+
+    def process_batch(self, context: dict) -> None:
+        """Flush staged batch records, then process any single-record queue."""
+        if not self.latest_state:
+            self.init_state()
+
+        raw_records = context.get("records") or []
+        try:
+            if raw_records:
+                try:
+                    response = self.make_batch_request(raw_records)
+                except Exception:
+                    self.logger.exception("Batch request failed for %s", self.name)
+                    self._fallback_batch_records(raw_records, context)
+                else:
+                    if is_whole_batch_failure(response):
+                        self._fallback_batch_records(raw_records, context)
+                    else:
+                        result = self.parse_batch_response(response, raw_records)
+                        for followup in result.get("association_followups", []):
+                            FallbackSink.put_associations(self, followup["id"], followup["associations"])
+                        for state in result.get("state_updates", []):
+                            if state.get("success"):
+                                self.logger.info("%s processed id: %s", self.name, state.get("id"))
+                            self.update_state(state)
+        finally:
+            for item in context.get("single_records") or []:
+                self.write_single_tap_record(item["record"], item.get("external_id"), context)
+            context["records"] = []
+            context["single_records"] = []

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -218,7 +218,11 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
     def build_staged_record_hash(self, staged: dict) -> str:
         """Hash a staged record the same way FallbackSink hashes preprocessed payloads."""
-        payload = {"properties": staged["properties"]}
+        properties = dict(staged["properties"])
+        hubspot_id = staged.get("id")
+        if hubspot_id and not properties.get("id"):
+            properties["id"] = hubspot_id
+        payload = {"properties": properties}
         if staged.get("associations"):
             payload["associations"] = staged["associations"]
         return self.build_record_hash(payload)

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -352,8 +352,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             self.logger.exception("Preprocess record error %s", exc)
             state_updates = {"error": str(exc)}
             state_updates.update(self._error_classification_metadata(exc))
-            success = None if isinstance(exc, InvalidPayloadError) else False
-            error_state = dict(success=success, **state_updates)
+            error_state = dict(success=False, **state_updates)
             if external_id:
                 error_state["externalId"] = external_id
             self.update_state(error_state, record=tap_record)

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -296,8 +296,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             self.update_state(existing_state, is_duplicate=True, record=staged["properties"])
             return
 
-        trace_id = external_id or record_hash
-        staged["trace_id"] = trace_id
+        staged["trace_id"] = record_hash
         staged["state"] = {"hash": record_hash}
         if external_id:
             staged["state"]["externalId"] = external_id

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -148,7 +148,14 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                 self.logger.info("%s processed id: %s", self.name, state.get("id"))
             self.update_state(state, is_duplicate=is_duplicate)
         for followup in result.get("association_followups", []):
-            FallbackSink.put_associations(self, followup["id"], followup["associations"])
+            try:
+                FallbackSink.put_associations(self, followup["id"], followup["associations"])
+            except Exception:
+                self.logger.exception(
+                    "Association follow-up failed for %s id %s",
+                    self.name,
+                    followup.get("id"),
+                )
 
     def _fallback_batch_records(self, staged_records: List[dict], context: dict) -> None:
         """Write each staged batch record through single-record FallbackSink."""
@@ -238,6 +245,20 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             self.logger.info("Record of type %s already exists with hash: %s", self.name, record_hash)
             return
 
+        flush_hashes = context.setdefault("flush_hashes", set())
+        if record_hash in flush_hashes:
+            self.logger.info(
+                "Record of type %s already staged in flush with hash: %s",
+                self.name,
+                record_hash,
+            )
+            dup_state = {"hash": record_hash}
+            if external_id:
+                dup_state["externalId"] = external_id
+            context.setdefault("flush_duplicate_states", []).append(dup_state)
+            return
+        flush_hashes.add(record_hash)
+
         existing_state = self.get_existing_state(record_hash)
         if existing_state:
             self.update_state(existing_state, is_duplicate=True, record=staged["properties"])
@@ -251,6 +272,18 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
 
         context.setdefault("records", []).append(staged)
 
+    def _apply_flush_duplicate_states(self, context: dict) -> None:
+        """Mark in-flush duplicate rows using the winner state after batch writes."""
+        for dup_state in context.get("flush_duplicate_states") or []:
+            existing_state = self.get_existing_state(dup_state["hash"])
+            if not existing_state:
+                continue
+            state = dict(existing_state)
+            external_id = dup_state.get("externalId")
+            if external_id:
+                state["externalId"] = external_id
+            self.update_state(state, is_duplicate=True)
+
     def process_batch(self, context: dict) -> None:
         """Flush staged batch records, then process any single-record queue."""
         if not self.latest_state:
@@ -260,8 +293,11 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         try:
             if raw_records:
                 self._process_staged_batch(raw_records, context)
+            self._apply_flush_duplicate_states(context)
         finally:
             for item in context.get("single_records") or []:
                 self.write_single_tap_record(item["record"], item.get("external_id"), context)
             context["records"] = []
             context["single_records"] = []
+            context["flush_hashes"] = set()
+            context["flush_duplicate_states"] = []

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -7,6 +7,10 @@ class ContactsFallbackSink(HubspotBatchSink):
     """Batched fallback sink for HubSpot contacts."""
 
     @property
+    def skip_staging_lookup(self) -> bool:
+        return True
+
+    @property
     def batch_id_property(self) -> str:
         return (self.lookup_fields or ["email"])[0]
 

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -79,28 +79,27 @@ class CompaniesFallbackSink(HubspotBatchSink):
         object_type = self.name
         id_property = self.batch_id_property
 
+        update_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPDATE]
+        upsert_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPSERT]
+        create_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_CREATE]
+
         by_kind = {
-            BATCH_KIND_UPDATE: dedupe_staged_by_hubspot_id(
-                [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPDATE]
-            ),
-            BATCH_KIND_UPSERT: dedupe_staged_by_key(
-                [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPSERT],
-                id_property,
-            ),
-            BATCH_KIND_CREATE: [
-                r for r in staged_records if r.get("batch_kind") == BATCH_KIND_CREATE
-            ],
+            BATCH_KIND_UPDATE: dedupe_staged_by_hubspot_id(update_staged),
+            BATCH_KIND_UPSERT: dedupe_staged_by_key(upsert_staged, id_property),
+            BATCH_KIND_CREATE: create_staged,
         }
 
         if by_kind[BATCH_KIND_UPDATE]:
             yield {
                 "records": by_kind[BATCH_KIND_UPDATE],
+                "staged_records": update_staged,
                 "request": lambda records: batch_update_objects(config, object_type, records),
                 "parse": parse_batch_update_response,
             }
         if by_kind[BATCH_KIND_UPSERT]:
             yield {
                 "records": by_kind[BATCH_KIND_UPSERT],
+                "staged_records": upsert_staged,
                 "request": lambda records: batch_upsert_objects(
                     config, object_type, id_property, records
                 ),
@@ -111,6 +110,7 @@ class CompaniesFallbackSink(HubspotBatchSink):
         if by_kind[BATCH_KIND_CREATE]:
             yield {
                 "records": by_kind[BATCH_KIND_CREATE],
+                "staged_records": create_staged,
                 "request": lambda records: batch_create_objects(config, object_type, records),
                 "parse": parse_batch_create_response,
             }

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -1,20 +1,5 @@
 """Stream-specific batch fallback sinks."""
 
-from typing import Iterator, List, Optional
-
-from target_hubspot_v4.batch import (
-    BATCH_KIND_CREATE,
-    BATCH_KIND_UPDATE,
-    BATCH_KIND_UPSERT,
-    batch_create_objects,
-    batch_update_objects,
-    batch_upsert_objects,
-    dedupe_staged_by_hubspot_id,
-    dedupe_staged_by_key,
-    parse_batch_create_response,
-    parse_batch_update_response,
-    parse_batch_upsert_response,
-)
 from target_hubspot_v4.batch_client import HubspotBatchSink
 
 
@@ -30,89 +15,11 @@ class CompaniesFallbackSink(HubspotBatchSink):
     """Batched fallback sink for HubSpot companies."""
 
     @property
+    def supports_batch_create(self) -> bool:
+        return True
+
+    @property
     def batch_id_property(self) -> str:
         if self.lookup_fields:
             return self.lookup_fields[0]
         return "name"
-
-    def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
-        """Stage companies for batch/update, batch/upsert, or batch/create."""
-        properties, associations = self.parse_fallback_properties(record)
-        hubspot_id = properties.get("id")
-
-        if hubspot_id:
-            return {
-                "properties": properties,
-                "associations": associations,
-                "batch_kind": BATCH_KIND_UPDATE,
-                "id": str(hubspot_id),
-            }
-
-        properties.pop("id", None)
-        if self.lookup_fields:
-            found_id = self._resolve_lookup_id(properties)
-            if found_id:
-                return {
-                    "properties": properties,
-                    "associations": associations,
-                    "batch_kind": BATCH_KIND_UPDATE,
-                    "id": found_id,
-                }
-
-            upsert_key = properties.get(self.batch_id_property)
-            if upsert_key:
-                id_property = self.batch_id_property
-                return {
-                    "properties": properties,
-                    "associations": associations,
-                    "batch_kind": BATCH_KIND_UPSERT,
-                    id_property: upsert_key,
-                }
-
-        return {
-            "properties": properties,
-            "associations": associations,
-            "batch_kind": BATCH_KIND_CREATE,
-        }
-
-    def iter_batch_requests(self, staged_records: List[dict]) -> Iterator[dict]:
-        """Route staged companies to batch/update, batch/upsert, or batch/create."""
-        config = self._target._config
-        object_type = self.name
-        id_property = self.batch_id_property
-
-        update_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPDATE]
-        upsert_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPSERT]
-        create_staged = [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_CREATE]
-
-        by_kind = {
-            BATCH_KIND_UPDATE: dedupe_staged_by_hubspot_id(update_staged),
-            BATCH_KIND_UPSERT: dedupe_staged_by_key(upsert_staged, id_property),
-            BATCH_KIND_CREATE: create_staged,
-        }
-
-        if by_kind[BATCH_KIND_UPDATE]:
-            yield {
-                "records": by_kind[BATCH_KIND_UPDATE],
-                "staged_records": update_staged,
-                "request": lambda records: batch_update_objects(config, object_type, records),
-                "parse": parse_batch_update_response,
-            }
-        if by_kind[BATCH_KIND_UPSERT]:
-            yield {
-                "records": by_kind[BATCH_KIND_UPSERT],
-                "staged_records": upsert_staged,
-                "request": lambda records: batch_upsert_objects(
-                    config, object_type, id_property, records
-                ),
-                "parse": lambda response, records: parse_batch_upsert_response(
-                    response, records, id_property
-                ),
-            }
-        if by_kind[BATCH_KIND_CREATE]:
-            yield {
-                "records": by_kind[BATCH_KIND_CREATE],
-                "staged_records": create_staged,
-                "request": lambda records: batch_create_objects(config, object_type, records),
-                "parse": parse_batch_create_response,
-            }

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -1,54 +1,116 @@
 """Stream-specific batch fallback sinks."""
 
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from hotglue_etl_exceptions import InvalidPayloadError
 
 from target_hubspot_v4.batch import (
-    batch_upsert_contacts,
-    dedupe_contacts_by_email,
-    parse_contact_batch_response,
+    BATCH_KIND_CREATE,
+    BATCH_KIND_UPDATE,
+    BATCH_KIND_UPSERT,
+    batch_create_objects,
+    batch_update_objects,
+    batch_upsert_objects,
+    dedupe_staged_by_hubspot_id,
+    dedupe_staged_by_key,
+    parse_batch_create_response,
+    parse_batch_update_response,
+    parse_batch_upsert_response,
 )
 from target_hubspot_v4.batch_client import HubspotBatchSink
 
 
 class ContactsFallbackSink(HubspotBatchSink):
-    """Batched fallback sink for HubSpot contacts using batch/upsert by email."""
+    """Batched fallback sink for HubSpot contacts."""
 
     @property
-    def endpoint(self):
-        return "/contacts"
+    def batch_id_property(self) -> str:
+        return (self.lookup_fields or ["email"])[0]
+
+
+class CompaniesFallbackSink(HubspotBatchSink):
+    """Batched fallback sink for HubSpot companies."""
+
+    @property
+    def batch_id_property(self) -> str:
+        if self.lookup_fields:
+            return self.lookup_fields[0]
+        return "name"
 
     def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
-        """Stage a contact for batch upsert when it has an email."""
+        """Stage companies for batch/update, batch/upsert, or batch/create."""
         properties, associations = self.parse_fallback_properties(record)
-        properties.pop("id", None)
-        email = properties.get("email")
-        if not email:
-            return None
+        hubspot_id = properties.get("id")
 
+        if hubspot_id:
+            return {
+                "properties": properties,
+                "associations": associations,
+                "batch_kind": BATCH_KIND_UPDATE,
+                "id": str(hubspot_id),
+            }
+
+        properties.pop("id", None)
         if self.lookup_fields:
-            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
-            if existing_objects and len(existing_objects) > 1:
-                raise InvalidPayloadError(
-                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
-                )
+            upsert_key = properties.get(self.batch_id_property)
+            if upsert_key:
+                existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
+                if existing_objects and len(existing_objects) > 1:
+                    raise InvalidPayloadError(
+                        f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
+                    )
+                id_property = self.batch_id_property
+                return {
+                    "properties": properties,
+                    "associations": associations,
+                    "batch_kind": BATCH_KIND_UPSERT,
+                    id_property: upsert_key,
+                }
 
         return {
             "properties": properties,
             "associations": associations,
-            "email": email,
+            "batch_kind": BATCH_KIND_CREATE,
         }
 
-    def make_batch_request(self, records: List[dict]):
-        """Send a deduped contacts batch/upsert request."""
-        deduped = dedupe_contacts_by_email(records)
-        return batch_upsert_contacts(self._target._config, deduped)
+    def iter_batch_requests(self, staged_records: List[dict]) -> Iterator[dict]:
+        """Route staged companies to batch/update, batch/upsert, or batch/create."""
+        config = self._target._config
+        object_type = self.name
+        id_property = self.batch_id_property
 
-    def parse_batch_response(self, response, staged_records: List[dict]) -> dict:
-        """Parse a contacts batch/upsert response into state updates."""
-        state_updates, association_followups = parse_contact_batch_response(response, staged_records)
-        return {
-            "state_updates": state_updates,
-            "association_followups": association_followups,
+        by_kind = {
+            BATCH_KIND_UPDATE: dedupe_staged_by_hubspot_id(
+                [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPDATE]
+            ),
+            BATCH_KIND_UPSERT: dedupe_staged_by_key(
+                [r for r in staged_records if r.get("batch_kind") == BATCH_KIND_UPSERT],
+                id_property,
+            ),
+            BATCH_KIND_CREATE: [
+                r for r in staged_records if r.get("batch_kind") == BATCH_KIND_CREATE
+            ],
         }
+
+        if by_kind[BATCH_KIND_UPDATE]:
+            yield {
+                "records": by_kind[BATCH_KIND_UPDATE],
+                "request": lambda records: batch_update_objects(config, object_type, records),
+                "parse": parse_batch_update_response,
+            }
+        if by_kind[BATCH_KIND_UPSERT]:
+            yield {
+                "records": by_kind[BATCH_KIND_UPSERT],
+                "request": lambda records: batch_upsert_objects(
+                    config, object_type, id_property, records
+                ),
+                "parse": lambda response, records: parse_batch_upsert_response(
+                    response, records, id_property
+                ),
+            }
+        if by_kind[BATCH_KIND_CREATE]:
+            yield {
+                "records": by_kind[BATCH_KIND_CREATE],
+                "request": lambda records: batch_create_objects(config, object_type, records),
+                "parse": parse_batch_create_response,
+            }

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -67,6 +67,20 @@ class CompaniesFallbackSink(HubspotBatchSink):
                     id_property: upsert_key,
                 }
 
+            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
+            if existing_objects and len(existing_objects) > 1:
+                raise InvalidPayloadError(
+                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
+                )
+            if existing_objects and len(existing_objects) == 1:
+                found_id = str(existing_objects[0]["id"])
+                return {
+                    "properties": properties,
+                    "associations": associations,
+                    "batch_kind": BATCH_KIND_UPDATE,
+                    "id": found_id,
+                }
+
         return {
             "properties": properties,
             "associations": associations,

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -2,8 +2,6 @@
 
 from typing import Iterator, List, Optional
 
-from hotglue_etl_exceptions import InvalidPayloadError
-
 from target_hubspot_v4.batch import (
     BATCH_KIND_CREATE,
     BATCH_KIND_UPDATE,
@@ -52,33 +50,23 @@ class CompaniesFallbackSink(HubspotBatchSink):
 
         properties.pop("id", None)
         if self.lookup_fields:
+            found_id = self._resolve_lookup_id(properties)
+            if found_id:
+                return {
+                    "properties": properties,
+                    "associations": associations,
+                    "batch_kind": BATCH_KIND_UPDATE,
+                    "id": found_id,
+                }
+
             upsert_key = properties.get(self.batch_id_property)
             if upsert_key:
-                existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
-                if existing_objects and len(existing_objects) > 1:
-                    raise InvalidPayloadError(
-                        f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
-                    )
                 id_property = self.batch_id_property
                 return {
                     "properties": properties,
                     "associations": associations,
                     "batch_kind": BATCH_KIND_UPSERT,
                     id_property: upsert_key,
-                }
-
-            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
-            if existing_objects and len(existing_objects) > 1:
-                raise InvalidPayloadError(
-                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
-                )
-            if existing_objects and len(existing_objects) == 1:
-                found_id = str(existing_objects[0]["id"])
-                return {
-                    "properties": properties,
-                    "associations": associations,
-                    "batch_kind": BATCH_KIND_UPDATE,
-                    "id": found_id,
                 }
 
         return {

--- a/target_hubspot_v4/batch_sinks.py
+++ b/target_hubspot_v4/batch_sinks.py
@@ -1,0 +1,54 @@
+"""Stream-specific batch fallback sinks."""
+
+from typing import List, Optional
+
+from hotglue_etl_exceptions import InvalidPayloadError
+
+from target_hubspot_v4.batch import (
+    batch_upsert_contacts,
+    dedupe_contacts_by_email,
+    parse_contact_batch_response,
+)
+from target_hubspot_v4.batch_client import HubspotBatchSink
+
+
+class ContactsFallbackSink(HubspotBatchSink):
+    """Batched fallback sink for HubSpot contacts using batch/upsert by email."""
+
+    @property
+    def endpoint(self):
+        return "/contacts"
+
+    def prepare_staged_record(self, record: dict, context: dict) -> Optional[dict]:
+        """Stage a contact for batch upsert when it has an email."""
+        properties, associations = self.parse_fallback_properties(record)
+        properties.pop("id", None)
+        email = properties.get("email")
+        if not email:
+            return None
+
+        if self.lookup_fields:
+            existing_objects = self.perform_object_lookup(properties, self.lookup_fields)
+            if existing_objects and len(existing_objects) > 1:
+                raise InvalidPayloadError(
+                    f"Multiple objects found for lookup fields {self.lookup_fields} on record {properties}"
+                )
+
+        return {
+            "properties": properties,
+            "associations": associations,
+            "email": email,
+        }
+
+    def make_batch_request(self, records: List[dict]):
+        """Send a deduped contacts batch/upsert request."""
+        deduped = dedupe_contacts_by_email(records)
+        return batch_upsert_contacts(self._target._config, deduped)
+
+    def parse_batch_response(self, response, staged_records: List[dict]) -> dict:
+        """Parse a contacts batch/upsert response into state updates."""
+        state_updates, association_followups = parse_contact_batch_response(response, staged_records)
+        return {
+            "state_updates": state_updates,
+            "association_followups": association_followups,
+        }

--- a/target_hubspot_v4/client.py
+++ b/target_hubspot_v4/client.py
@@ -92,6 +92,35 @@ class HubspotSink(HotglueSink):
             obj = json.dumps(obj)
         return obj
 
+    def perform_object_lookup(self, record: dict, lookup_fields):
+        if len(lookup_fields) == 0:
+            return []
+        if len(lookup_fields) == 1:
+            lookup_field = lookup_fields[0]
+            if not record.get(lookup_field):
+                return []
+
+            return utils.search_objects_by_property(
+                self._target._config,
+                self.name,
+                [{"property_name": lookup_field, "value": record[lookup_field]}]
+            )
+        else:
+            if self.lookup_method == "sequential":
+                for lookup_field in lookup_fields:
+                    matches = self.perform_object_lookup(record, [lookup_field])
+                    if matches and len(matches) == 1:
+                        return [matches[0]]
+                return []
+            else:
+                if not all(record.get(lookup_field) for lookup_field in lookup_fields):
+                    return []
+                return utils.search_objects_by_property(
+                    self._target._config,
+                    self.name,
+                    [{"property_name": lookup_field, "value": record[lookup_field]} for lookup_field in lookup_fields]
+                )
+
     def validate_response(self, response: requests.Response) -> None:
         utils.raise_etl_exceptions(response)
         return super().validate_response(response)

--- a/target_hubspot_v4/sinks.py
+++ b/target_hubspot_v4/sinks.py
@@ -1,7 +1,7 @@
 """Hubspot-v4 target sink class, which handles writing streams."""
 
 from target_hubspot_v4.client import HubspotSink
-from target_hubspot_v4.utils import request_push, search_objects_by_property
+from target_hubspot_v4.utils import request_push
 from hotglue_etl_exceptions import InvalidPayloadError
 
 class FallbackSink(HubspotSink):
@@ -21,35 +21,6 @@ class FallbackSink(HubspotSink):
     @property
     def name(self):
         return self.stream_name
-
-    def perform_object_lookup(self, record: dict, lookup_fields):
-        if len(lookup_fields) == 0:
-            return []
-        if len(lookup_fields) == 1:
-            lookup_field = lookup_fields[0]
-            if not record.get(lookup_field):
-                return []
-
-            return search_objects_by_property(
-                self._target._config,
-                self.name,
-                [{"property_name": lookup_field, "value": record[lookup_field]}]
-            )
-        else:
-            if self.lookup_method == "sequential":
-                for lookup_field in lookup_fields:
-                    matches = self.perform_object_lookup(record, [lookup_field])
-                    if matches and len(matches) == 1:
-                        return [matches[0]]
-                return []
-            else:
-                if not all(record.get(lookup_field) for lookup_field in lookup_fields):
-                    return []
-                return search_objects_by_property(
-                    self._target._config,
-                    self.name,
-                    [{"property_name": lookup_field, "value": record[lookup_field]} for lookup_field in lookup_fields]
-                )
 
     def preprocess_record(self, record: dict, context: dict) -> None:
         """Process the record."""

--- a/target_hubspot_v4/target.py
+++ b/target_hubspot_v4/target.py
@@ -7,6 +7,7 @@ from hotglue_singer_sdk import typing as th
 from hotglue_singer_sdk.sinks import Sink
 from hotglue_singer_sdk.helpers.capabilities import AlertingLevel
 
+from target_hubspot_v4.batch_sinks import ContactsFallbackSink
 from target_hubspot_v4.sinks import (
     FallbackSink,
 )
@@ -49,13 +50,19 @@ class TargetHubspotv4(TargetHotglue):
         ),
     ).to_dict()
 
+    BATCH_FALLBACK_SINKS = {
+        "contacts": ContactsFallbackSink,
+    }
+
     def get_sink_class(self, stream_name: str) -> Type[Sink]:
         # Check if unified sinks are enabled
         if self.config.get("unified_api_schema", False):
             return UnifiedSink
 
-        for sink_class in self.SINK_TYPES:
-            return FallbackSink
+        if stream_name in self.BATCH_FALLBACK_SINKS and self.config.get("batch_contacts", True):
+            return self.BATCH_FALLBACK_SINKS[stream_name]
+
+        return FallbackSink
 
 if __name__ == "__main__":
     TargetHubspotv4.cli()

--- a/target_hubspot_v4/target.py
+++ b/target_hubspot_v4/target.py
@@ -7,7 +7,7 @@ from hotglue_singer_sdk import typing as th
 from hotglue_singer_sdk.sinks import Sink
 from hotglue_singer_sdk.helpers.capabilities import AlertingLevel
 
-from target_hubspot_v4.batch_sinks import ContactsFallbackSink
+from target_hubspot_v4.batch_sinks import CompaniesFallbackSink, ContactsFallbackSink
 from target_hubspot_v4.sinks import (
     FallbackSink,
 )
@@ -52,6 +52,12 @@ class TargetHubspotv4(TargetHotglue):
 
     BATCH_FALLBACK_SINKS = {
         "contacts": ContactsFallbackSink,
+        "companies": CompaniesFallbackSink,
+    }
+
+    BATCH_CONFIG_KEYS = {
+        "contacts": "batch_contacts",
+        "companies": "batch_companies",
     }
 
     def get_sink_class(self, stream_name: str) -> Type[Sink]:
@@ -59,8 +65,10 @@ class TargetHubspotv4(TargetHotglue):
         if self.config.get("unified_api_schema", False):
             return UnifiedSink
 
-        if stream_name in self.BATCH_FALLBACK_SINKS and self.config.get("batch_contacts", True):
-            return self.BATCH_FALLBACK_SINKS[stream_name]
+        if stream_name in self.BATCH_FALLBACK_SINKS:
+            config_key = self.BATCH_CONFIG_KEYS[stream_name]
+            if self.config.get(config_key, True):
+                return self.BATCH_FALLBACK_SINKS[stream_name]
 
         return FallbackSink
 

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -12,7 +12,6 @@ from target_hubspot_v4.batch import (
     parse_batch_upsert_response,
 )
 from target_hubspot_v4.batch_sinks import CompaniesFallbackSink, ContactsFallbackSink
-from target_hubspot_v4.sinks import FallbackSink
 
 
 def _make_sink(sink_cls, stream_name, lookup_fields=None):
@@ -84,36 +83,31 @@ class TestContactsStaging:
         assert staged["id"] == "123"
 
     @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[])
-    def test_email_without_id_stages_upsert(self, _lookup):
+    def test_email_without_id_stages_upsert(self, lookup):
         sink = _make_sink(ContactsFallbackSink, "contacts")
         staged = sink.prepare_staged_record({"email": "a@example.com", "firstname": "Ann"}, {})
         assert staged["batch_kind"] == BATCH_KIND_UPSERT
         assert staged["email"] == "a@example.com"
+        lookup.assert_not_called()
 
     def test_missing_email_returns_none(self):
         sink = _make_sink(ContactsFallbackSink, "contacts")
         assert sink.prepare_staged_record({"firstname": "Ann"}, {}) is None
 
     @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
-    def test_lookup_match_stages_update(self, _lookup):
+    def test_email_stages_upsert_without_staging_lookup(self, lookup):
         sink = _make_sink(ContactsFallbackSink, "contacts", lookup_fields=["email"])
-        staged = sink.prepare_staged_record({"email": "a@example.com"}, {})
-        assert staged["batch_kind"] == BATCH_KIND_UPDATE
-        assert staged["id"] == "456"
+        staged = sink.prepare_staged_record({"email": "a@example.com", "firstname": "Ann"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPSERT
+        assert staged["email"] == "a@example.com"
+        lookup.assert_not_called()
 
-    @patch.object(FallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
-    @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
-    def test_lookup_update_hash_matches_fallback_preprocess(self, _batch_lookup, _fallback_lookup):
-        sink = _make_sink(ContactsFallbackSink, "contacts", lookup_fields=["email"])
-        record = {"email": "a@example.com", "firstname": "Ann"}
-        staged = sink.prepare_staged_record(record, {})
-        batch_hash = sink.build_staged_record_hash(staged)
-        fallback_sink = FallbackSink(sink._target, "contacts", sink.schema, sink.key_properties)
-        fallback_payload = FallbackSink.preprocess_record(fallback_sink, dict(record), {})
-        fallback_hash = sink.build_record_hash(fallback_payload)
-        assert batch_hash == fallback_hash
-        assert "id" not in staged["properties"]
-        assert staged["id"] == "456"
+    def test_upsert_hash_ignores_resolved_lookup_id(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        staged = sink.prepare_staged_record({"email": "a@example.com", "firstname": "Ann"}, {})
+        assert sink.build_staged_record_hash(staged) == sink.build_record_hash(
+            {"properties": {"email": "a@example.com", "firstname": "Ann"}}
+        )
 
 
 class TestCompaniesStaging:

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -12,6 +12,7 @@ from target_hubspot_v4.batch import (
     parse_batch_upsert_response,
 )
 from target_hubspot_v4.batch_sinks import CompaniesFallbackSink, ContactsFallbackSink
+from target_hubspot_v4.sinks import FallbackSink
 
 
 def _make_sink(sink_cls, stream_name, lookup_fields=None):
@@ -98,6 +99,20 @@ class TestContactsStaging:
         sink = _make_sink(ContactsFallbackSink, "contacts", lookup_fields=["email"])
         staged = sink.prepare_staged_record({"email": "a@example.com"}, {})
         assert staged["batch_kind"] == BATCH_KIND_UPDATE
+        assert staged["id"] == "456"
+
+    @patch.object(FallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
+    @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
+    def test_lookup_update_hash_matches_fallback_preprocess(self, _batch_lookup, _fallback_lookup):
+        sink = _make_sink(ContactsFallbackSink, "contacts", lookup_fields=["email"])
+        record = {"email": "a@example.com", "firstname": "Ann"}
+        staged = sink.prepare_staged_record(record, {})
+        batch_hash = sink.build_staged_record_hash(staged)
+        fallback_sink = FallbackSink(sink._target, "contacts", sink.schema, sink.key_properties)
+        fallback_payload = FallbackSink.preprocess_record(fallback_sink, dict(record), {})
+        fallback_hash = sink.build_record_hash(fallback_payload)
+        assert batch_hash == fallback_hash
+        assert "id" not in staged["properties"]
         assert staged["id"] == "456"
 
 

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -1,0 +1,191 @@
+"""Unit tests for HubSpot batch helpers and sink routing."""
+
+from unittest.mock import MagicMock, patch
+
+from target_hubspot_v4.batch import (
+    BATCH_KIND_CREATE,
+    BATCH_KIND_UPDATE,
+    BATCH_KIND_UPSERT,
+    build_trace_id,
+    is_whole_batch_failure,
+    parse_batch_update_response,
+    parse_batch_upsert_response,
+)
+from target_hubspot_v4.batch_sinks import CompaniesFallbackSink, ContactsFallbackSink
+
+
+def _make_sink(sink_cls, stream_name, lookup_fields=None):
+    """Build a batch sink with a mocked target and optional lookup_fields config."""
+    config = {"access_token": "test-token"}
+    if lookup_fields is not None:
+        config["lookup_fields"] = {stream_name: lookup_fields}
+    target = MagicMock()
+    target.config = config
+    target._config = config
+    target.EXTERNAL_ID_KEY = "externalId"
+    schema = {"type": "object", "properties": {"email": {"type": "string"}}}
+    return sink_cls(target=target, stream_name=stream_name, schema=schema, key_properties=[])
+
+
+def _staged(state_hash, **extra):
+    """Build a minimal staged batch record for parse/response tests."""
+    staged = {
+        "properties": extra.pop("properties", {}),
+        "state": {"hash": state_hash},
+        "trace_id": state_hash,
+    }
+    staged.update(extra)
+    return staged
+
+
+class TestBatchHelpers:
+    """Low-level batch.py helpers: trace ids, failure detection, dedupe parsing."""
+
+    def test_build_trace_id_uses_record_hash(self):
+        staged = {"trace_id": "abc123", "state": {"hash": "abc123", "externalId": "ext-1"}}
+        assert build_trace_id(staged) == "abc123"
+
+    def test_is_whole_batch_failure_parses_409_with_results(self):
+        response = MagicMock(status_code=409)
+        response.json.return_value = {
+            "results": [{"objectWriteTraceId": "hash-1", "id": "1"}],
+            "errors": [],
+        }
+        assert is_whole_batch_failure(response) is False
+
+    def test_parse_superseded_row_gets_success(self):
+        response = MagicMock(status_code=207)
+        response.json.return_value = {
+            "results": [{"objectWriteTraceId": "winner", "id": "999"}],
+            "errors": [],
+        }
+        staged_records = [
+            _staged("loser", properties={"email": "a@example.com"}, email="a@example.com"),
+            _staged("winner", properties={"email": "a@example.com"}, email="a@example.com"),
+        ]
+        state_updates, _ = parse_batch_upsert_response(response, staged_records, "email")
+        loser = next(s for s in state_updates if s["hash"] == "loser")
+        assert loser["success"] is True
+        assert loser["_duplicate"] is True
+        assert loser["id"] == "999"
+
+
+class TestContactsStaging:
+    """prepare_staged_record routing for contacts (update / upsert / single fallback)."""
+
+    def test_explicit_id_stages_update(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        staged = sink.prepare_staged_record(
+            {"email": "a@example.com", "id": "123", "firstname": "Ann"},
+            {},
+        )
+        assert staged["batch_kind"] == BATCH_KIND_UPDATE
+        assert staged["id"] == "123"
+
+    @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[])
+    def test_email_without_id_stages_upsert(self, _lookup):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        staged = sink.prepare_staged_record({"email": "a@example.com", "firstname": "Ann"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPSERT
+        assert staged["email"] == "a@example.com"
+
+    def test_missing_email_returns_none(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        assert sink.prepare_staged_record({"firstname": "Ann"}, {}) is None
+
+    @patch.object(ContactsFallbackSink, "perform_object_lookup", return_value=[{"id": "456"}])
+    def test_lookup_match_stages_update(self, _lookup):
+        sink = _make_sink(ContactsFallbackSink, "contacts", lookup_fields=["email"])
+        staged = sink.prepare_staged_record({"email": "a@example.com"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPDATE
+        assert staged["id"] == "456"
+
+
+class TestCompaniesStaging:
+    """prepare_staged_record routing for companies (update / upsert / create)."""
+
+    def test_explicit_id_stages_update(self):
+        sink = _make_sink(CompaniesFallbackSink, "companies")
+        staged = sink.prepare_staged_record({"id": "123", "name": "Acme"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPDATE
+        assert staged["id"] == "123"
+
+    def test_name_without_id_stages_upsert(self):
+        sink = _make_sink(CompaniesFallbackSink, "companies")
+        staged = sink.prepare_staged_record({"name": "Acme"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPSERT
+        assert staged["name"] == "Acme"
+
+    def test_no_key_stages_create(self):
+        sink = _make_sink(CompaniesFallbackSink, "companies")
+        staged = sink.prepare_staged_record({"domain": "acme.example"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_CREATE
+
+    @patch.object(CompaniesFallbackSink, "perform_object_lookup", return_value=[{"id": "789"}])
+    def test_lookup_without_name_stages_update(self, _lookup):
+        sink = _make_sink(CompaniesFallbackSink, "companies", lookup_fields=["name"])
+        staged = sink.prepare_staged_record({"domain": "acme.example"}, {})
+        assert staged["batch_kind"] == BATCH_KIND_UPDATE
+        assert staged["id"] == "789"
+
+
+class TestBatchRouting:
+    """iter_batch_requests splits and batch response parsing."""
+
+    def test_contacts_split_update_and_upsert(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        staged_records = [
+            {"batch_kind": BATCH_KIND_UPDATE, "id": "1", "properties": {"email": "a@example.com"}},
+            {"batch_kind": BATCH_KIND_UPSERT, "email": "b@example.com", "properties": {"email": "b@example.com"}},
+        ]
+        specs = list(sink.iter_batch_requests(staged_records))
+        assert len(specs) == 2
+        assert specs[0]["records"][0]["id"] == "1"
+        assert specs[1]["records"][0]["email"] == "b@example.com"
+
+    def test_companies_split_all_three_kinds(self):
+        sink = _make_sink(CompaniesFallbackSink, "companies")
+        staged_records = [
+            {"batch_kind": BATCH_KIND_UPDATE, "id": "1", "properties": {"name": "A"}},
+            {"batch_kind": BATCH_KIND_UPSERT, "name": "B", "properties": {"name": "B"}},
+            {"batch_kind": BATCH_KIND_CREATE, "properties": {"domain": "c.example"}},
+        ]
+        specs = list(sink.iter_batch_requests(staged_records))
+        assert len(specs) == 3
+
+    def test_update_response_maps_by_hubspot_id(self):
+        response = MagicMock(status_code=207)
+        response.json.return_value = {
+            "results": [{"objectWriteTraceId": "hash-1", "id": "123"}],
+            "errors": [],
+        }
+        staged_records = [
+            _staged("hash-1", properties={"name": "Acme"}, id="123", batch_kind=BATCH_KIND_UPDATE),
+        ]
+        state_updates, _ = parse_batch_update_response(response, staged_records)
+        assert state_updates[0]["success"] is True
+        assert state_updates[0]["id"] == "123"
+
+
+class TestFlushDuplicateStates:
+    """In-flush duplicate rows inherit the winner bookmark state."""
+
+    def test_duplicate_gets_winner_error_state(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        sink.latest_state = {
+            "bookmarks": {
+                "contacts": [{"hash": "dup-hash", "success": False, "error": "boom"}],
+            },
+            "summary": {
+                "contacts": {"success": 0, "fail": 0, "existing": 0, "updated": 0},
+            },
+        }
+        sink.summary_init = True
+        context = {"flush_duplicate_states": [{"hash": "dup-hash", "externalId": "ext-1"}]}
+        sink._apply_flush_duplicate_states(context)
+        bookmarks = sink.latest_state["bookmarks"]["contacts"]
+        assert len(bookmarks) == 2
+        dup = bookmarks[-1]
+        assert dup["success"] is False
+        assert dup["error"] == "boom"
+        assert dup["externalId"] == "ext-1"


### PR DESCRIPTION
Adds HubSpot CRM batch API support for contacts and companies on the existing FallbackSink path. Batch mode is enabled by default per stream via `batch_contacts` and `batch_companies` (both default to `true`). Set either flag to `false` to keep the single-record FallbackSink.

Records are staged into up to three batch groups per flush (100 records max each):
- **batch/update** when the row has a HubSpot `id` (all streams), or when lookup resolves to exactly one object (**companies only**)
- **batch/upsert** when an upsert key is present: email for contacts (direct upsert, no pre-batch search), first lookup field or `name` for companies
- **batch/create** for companies with no id and no upsert key

Contacts skip staging lookup (`skip_staging_lookup`) so email rows go straight to `batch/upsert` instead of search-then-update. That matches HubSpot upsert semantics and avoids redundant search calls. Explicit HubSpot `id` on a contact still routes to `batch/update`.

The implementation reuses FallbackSink for anything that cannot be batched (contacts without email, lookup errors, whole-batch failures, partial apply gaps). Batch responses are correlated with staged rows using the record content hash as `objectWriteTraceId`. Associations are applied after successful writes. In-flush duplicates are last-wins deduped at the API payload level, with loser rows marked from the winner's state.

## Changed files
- **batch.py** (new): Low-level HubSpot batch API helpers. Builds update/upsert/create payloads, sends requests with the same retry behavior as single-record writes, and parses responses back into state updates (including 409 partial failures and superseded rows).
- **batch_client.py** (new): `HubspotBatchSink` base class. Stages records, routes them into batch request groups, flushes via the batch API, and falls back to FallbackSink when a row or whole request cannot be batched.
- **batch_sinks.py** (new): Stream-specific sinks. `ContactsFallbackSink` upserts on email with staging lookup skipped; `CompaniesFallbackSink` also supports batch/create when no upsert key is available.
- **client.py**: Moves `perform_object_lookup` up to `HubspotSink` so both FallbackSink and the new batch sinks share the same lookup logic.
- **sinks.py**: Removes the duplicated lookup method now living on `HubspotSink`. FallbackSink itself is unchanged in behavior.
- **target.py**: Selects the batch fallback sink for contacts/companies when the corresponding config flag is enabled.
- **tests/test_batch.py** (new): Unit tests for the batch layer