### PR TITLE
HGI-10681: fall back to single writes when batch/update omits results

### DIFF
--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -30,9 +30,9 @@ def missing_batch_result_error(batch_kind: str) -> str:
     return f"{MISSING_BATCH_RESULT_ERROR_PREFIX}{batch_kind}"
 
 
-def is_missing_batch_result_error(message: Optional[str]) -> bool:
-    """Return True when a batch parser could not map a HubSpot per-record outcome."""
-    return bool(message) and message.startswith(MISSING_BATCH_RESULT_ERROR_PREFIX)
+def should_fallback_missing_batch_result(message: Optional[str]) -> bool:
+    """Return True when a missing batch outcome should defer state and single-write fallback."""
+    return message == missing_batch_result_error(BATCH_KIND_UPDATE)
 
 
 def build_trace_id(staged: dict) -> str:

--- a/target_hubspot_v4/batch.py
+++ b/target_hubspot_v4/batch.py
@@ -22,6 +22,18 @@ BATCH_KIND_UPDATE = "update"
 BATCH_KIND_UPSERT = "upsert"
 BATCH_KIND_CREATE = "create"
 
+MISSING_BATCH_RESULT_ERROR_PREFIX = "Missing result from batch "
+
+
+def missing_batch_result_error(batch_kind: str) -> str:
+    """Return the parser error when HubSpot omits a per-record batch outcome."""
+    return f"{MISSING_BATCH_RESULT_ERROR_PREFIX}{batch_kind}"
+
+
+def is_missing_batch_result_error(message: Optional[str]) -> bool:
+    """Return True when a batch parser could not map a HubSpot per-record outcome."""
+    return bool(message) and message.startswith(MISSING_BATCH_RESULT_ERROR_PREFIX)
+
 
 def build_trace_id(staged: dict) -> str:
     """Return a unique batch trace id from the staged record hash."""
@@ -148,12 +160,42 @@ def _post_batch(config: dict, url: str, payload: dict):
     return SESSION.send(req)
 
 
+def summarize_batch_response(response, input_count: int) -> dict:
+    """Return a compact summary of a HubSpot batch API response for logging."""
+    summary = {
+        "status_code": getattr(response, "status_code", None),
+        "inputs": input_count,
+        "results": 0,
+        "errors": 0,
+    }
+    if response is None:
+        return summary
+
+    try:
+        body = response.json()
+    except (ValueError, TypeError):
+        summary["body_parse_failed"] = True
+        return summary
+
+    summary["results"] = len(body.get("results") or [])
+    summary["errors"] = len(body.get("errors") or [])
+    if body.get("numErrors") is not None:
+        summary["num_errors"] = body["numErrors"]
+    if body.get("status"):
+        summary["completion_status"] = body["status"]
+    if summary["results"] == 0 and summary["errors"] == 0 and body.get("message"):
+        summary["message"] = str(body["message"])[:200]
+    return summary
+
+
 def _send_batch(config: dict, url: str, payload: dict):
     """POST a batch request and return responses that may include partial success."""
     if not payload.get("inputs"):
         return None
 
+    input_count = len(payload["inputs"])
     resp = _post_batch(config, url, payload)
+    logger.info("Batch response summary: %s", summarize_batch_response(resp, input_count))
     if resp.status_code in (200, 201, 207, 400, 409):
         return resp
 
@@ -302,7 +344,7 @@ def parse_batch_upsert_response(
         response,
         staged_records,
         lambda staged: get_upsert_key(staged, id_property),
-        "Missing result from batch upsert",
+        missing_batch_result_error(BATCH_KIND_UPSERT),
     )
 
 
@@ -315,7 +357,7 @@ def parse_batch_update_response(
         response,
         staged_records,
         get_hubspot_id,
-        "Missing result from batch update",
+        missing_batch_result_error(BATCH_KIND_UPDATE),
     )
 
 
@@ -328,7 +370,7 @@ def parse_batch_create_response(
         response,
         staged_records,
         lambda _staged: None,
-        "Missing result from batch create",
+        missing_batch_result_error(BATCH_KIND_CREATE),
     )
 
 

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -245,13 +245,16 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
             if self._staged_record_hash(staged) not in applied_hashes
         ]
 
-    def _apply_batch_result(self, result: dict) -> set:
+    def _apply_batch_result(self, result: dict) -> tuple:
         """Apply parsed batch state updates and association followups."""
         applied_hashes = set()
+        deferred_hashes = set()
         for state in result.get("state_updates", []):
             is_duplicate = state.pop("_duplicate", False)
             record_hash = state.get("hash")
             if not state.get("success") and should_fallback_missing_batch_result(state.get("error")):
+                if record_hash:
+                    deferred_hashes.add(record_hash)
                 continue
             try:
                 if state.get("success"):
@@ -274,7 +277,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                     self.name,
                     followup.get("id"),
                 )
-        return applied_hashes
+        return applied_hashes, deferred_hashes
 
     def _fallback_batch_records(
         self,
@@ -333,32 +336,48 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                         self.logger.exception("Batch result parsing failed for %s", self.name)
                         self._fallback_batch_records(parse_records, context)
                     else:
-                        applied_hashes = self._apply_batch_result(parsed)
+                        applied_hashes, deferred_hashes = self._apply_batch_result(parsed)
                         unapplied = self._unapplied_staged_records(parse_records, applied_hashes)
-                        fallback_candidates = [
+                        missing_result_candidates = [
                             staged
                             for staged in unapplied
-                            if staged.get("batch_kind") == BATCH_KIND_UPDATE
+                            if self._staged_record_hash(staged) in deferred_hashes
                         ]
-                        if fallback_candidates:
+                        other_unapplied = [
+                            staged
+                            for staged in unapplied
+                            if self._staged_record_hash(staged) not in deferred_hashes
+                        ]
+                        if missing_result_candidates:
                             missing_refs = [
                                 {
                                     "externalId": (staged.get("state") or {}).get("externalId"),
                                     "id": staged.get("id"),
                                     "hash": (staged.get("state") or {}).get("hash"),
                                 }
-                                for staged in fallback_candidates
+                                for staged in missing_result_candidates
                             ]
                             self.logger.warning(
                                 "Batch apply incomplete for %s; %d batch/update records missing HubSpot outcomes: %s",
                                 self.name,
-                                len(fallback_candidates),
+                                len(missing_result_candidates),
                                 missing_refs,
                             )
                             self._fallback_batch_records(
-                                fallback_candidates,
+                                missing_result_candidates,
                                 context,
                                 reason="missing per-record batch update results",
+                            )
+                        if other_unapplied:
+                            self.logger.warning(
+                                "Batch apply incomplete for %s; falling back on %d records",
+                                self.name,
+                                len(other_unapplied),
+                            )
+                            self._fallback_batch_records(
+                                other_unapplied,
+                                context,
+                                reason="batch apply incomplete",
                             )
 
     def process_record(self, record: dict, context: dict) -> None:

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -10,7 +10,7 @@ from target_hubspot_v4.batch import (
     BATCH_KIND_CREATE,
     BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
-    is_missing_batch_result_error,
+    should_fallback_missing_batch_result,
     batch_create_objects,
     batch_update_objects,
     batch_upsert_objects,
@@ -251,7 +251,7 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         for state in result.get("state_updates", []):
             is_duplicate = state.pop("_duplicate", False)
             record_hash = state.get("hash")
-            if not state.get("success") and is_missing_batch_result_error(state.get("error")):
+            if not state.get("success") and should_fallback_missing_batch_result(state.get("error")):
                 continue
             try:
                 if state.get("success"):
@@ -335,25 +335,30 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                     else:
                         applied_hashes = self._apply_batch_result(parsed)
                         unapplied = self._unapplied_staged_records(parse_records, applied_hashes)
-                        if unapplied:
+                        fallback_candidates = [
+                            staged
+                            for staged in unapplied
+                            if staged.get("batch_kind") == BATCH_KIND_UPDATE
+                        ]
+                        if fallback_candidates:
                             missing_refs = [
                                 {
                                     "externalId": (staged.get("state") or {}).get("externalId"),
                                     "id": staged.get("id"),
                                     "hash": (staged.get("state") or {}).get("hash"),
                                 }
-                                for staged in unapplied
+                                for staged in fallback_candidates
                             ]
                             self.logger.warning(
-                                "Batch apply incomplete for %s; %d records missing HubSpot outcomes: %s",
+                                "Batch apply incomplete for %s; %d batch/update records missing HubSpot outcomes: %s",
                                 self.name,
-                                len(unapplied),
+                                len(fallback_candidates),
                                 missing_refs,
                             )
                             self._fallback_batch_records(
-                                unapplied,
+                                fallback_candidates,
                                 context,
-                                reason="missing per-record batch results",
+                                reason="missing per-record batch update results",
                             )
 
     def process_record(self, record: dict, context: dict) -> None:

--- a/target_hubspot_v4/batch_client.py
+++ b/target_hubspot_v4/batch_client.py
@@ -10,6 +10,7 @@ from target_hubspot_v4.batch import (
     BATCH_KIND_CREATE,
     BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
+    is_missing_batch_result_error,
     batch_create_objects,
     batch_update_objects,
     batch_upsert_objects,
@@ -250,6 +251,8 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
         for state in result.get("state_updates", []):
             is_duplicate = state.pop("_duplicate", False)
             record_hash = state.get("hash")
+            if not state.get("success") and is_missing_batch_result_error(state.get("error")):
+                continue
             try:
                 if state.get("success"):
                     self.logger.info("%s processed id: %s", self.name, state.get("id"))
@@ -273,11 +276,19 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                 )
         return applied_hashes
 
-    def _fallback_batch_records(self, staged_records: List[dict], context: dict) -> None:
+    def _fallback_batch_records(
+        self,
+        staged_records: List[dict],
+        context: dict,
+        *,
+        reason: str = "entire batch failure",
+    ) -> None:
         """Write each staged batch record through single-record FallbackSink."""
         self.logger.warning(
-            "Batch request for %s failed entirely; falling back to single-record writes",
+            "Batch request for %s incomplete (%s); falling back to single-record writes for %d records",
             self.name,
+            reason,
+            len(staged_records),
         )
         for staged in staged_records:
             self.write_single_staged_record(staged, context)
@@ -325,12 +336,25 @@ class HubspotBatchSink(HubspotSink, HotglueBatchSink):
                         applied_hashes = self._apply_batch_result(parsed)
                         unapplied = self._unapplied_staged_records(parse_records, applied_hashes)
                         if unapplied:
+                            missing_refs = [
+                                {
+                                    "externalId": (staged.get("state") or {}).get("externalId"),
+                                    "id": staged.get("id"),
+                                    "hash": (staged.get("state") or {}).get("hash"),
+                                }
+                                for staged in unapplied
+                            ]
                             self.logger.warning(
-                                "Batch apply incomplete for %s; falling back on %d records",
+                                "Batch apply incomplete for %s; %d records missing HubSpot outcomes: %s",
                                 self.name,
                                 len(unapplied),
+                                missing_refs,
                             )
-                            self._fallback_batch_records(unapplied, context)
+                            self._fallback_batch_records(
+                                unapplied,
+                                context,
+                                reason="missing per-record batch results",
+                            )
 
     def process_record(self, record: dict, context: dict) -> None:
         """Stage a record for batch write, or queue it for single-record FallbackSink."""

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -234,9 +234,10 @@ class TestMissingBatchResultFallback:
             "association_followups": [],
         }
 
-        applied_hashes = sink._apply_batch_result(parsed)
+        applied_hashes, deferred_hashes = sink._apply_batch_result(parsed)
 
         assert applied_hashes == {"hash-1"}
+        assert deferred_hashes == {"hash-2"}
         sink.update_state.assert_called_once()
 
     def test_missing_upsert_result_state_is_applied_as_failure(self):
@@ -254,9 +255,10 @@ class TestMissingBatchResultFallback:
             "association_followups": [],
         }
 
-        applied_hashes = sink._apply_batch_result(parsed)
+        applied_hashes, deferred_hashes = sink._apply_batch_result(parsed)
 
         assert applied_hashes == {"hash-2"}
+        assert deferred_hashes == set()
         sink.update_state.assert_called_once()
 
 

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -7,9 +7,9 @@ from target_hubspot_v4.batch import (
     BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
     build_trace_id,
-    is_missing_batch_result_error,
     is_whole_batch_failure,
     missing_batch_result_error,
+    should_fallback_missing_batch_result,
     parse_batch_update_response,
     parse_batch_upsert_response,
     summarize_batch_response,
@@ -56,10 +56,12 @@ class TestBatchHelpers:
         }
         assert is_whole_batch_failure(response) is False
 
-    def test_missing_batch_result_error_uses_batch_kind(self):
+    def test_missing_batch_result_helpers(self):
         assert missing_batch_result_error(BATCH_KIND_UPDATE) == "Missing result from batch update"
-        assert is_missing_batch_result_error(missing_batch_result_error(BATCH_KIND_UPSERT)) is True
-        assert is_missing_batch_result_error("Some other error") is False
+        assert missing_batch_result_error(BATCH_KIND_UPSERT) == "Missing result from batch upsert"
+        assert should_fallback_missing_batch_result(missing_batch_result_error(BATCH_KIND_UPDATE)) is True
+        assert should_fallback_missing_batch_result(missing_batch_result_error(BATCH_KIND_UPSERT)) is False
+        assert should_fallback_missing_batch_result(missing_batch_result_error(BATCH_KIND_CREATE)) is False
 
     def test_summarize_batch_response_counts_results_and_errors(self):
         response = MagicMock(status_code=207)
@@ -217,19 +219,13 @@ class TestBatchRouting:
 
 
 class TestMissingBatchResultFallback:
-    """Records omitted from HubSpot batch responses fall back to single writes."""
+    """Batch/update rows omitted from HubSpot responses fall back to single writes."""
 
-    def test_missing_batch_result_state_is_not_applied(self):
+    def test_missing_update_result_state_is_not_applied(self):
         sink = _make_sink(CompaniesFallbackSink, "companies")
         sink.update_state = MagicMock()
         sink.write_single_staged_record = MagicMock()
 
-        staged = _staged(
-            "hash-2",
-            properties={"name": "Beta", "id": "456"},
-            id="456",
-            batch_kind=BATCH_KIND_UPDATE,
-        )
         parsed = {
             "state_updates": [
                 {"hash": "hash-1", "success": True, "id": "123"},
@@ -242,8 +238,26 @@ class TestMissingBatchResultFallback:
 
         assert applied_hashes == {"hash-1"}
         sink.update_state.assert_called_once()
-        unapplied = sink._unapplied_staged_records([staged], applied_hashes)
-        assert unapplied == [staged]
+
+    def test_missing_upsert_result_state_is_applied_as_failure(self):
+        sink = _make_sink(ContactsFallbackSink, "contacts")
+        sink.update_state = MagicMock()
+
+        parsed = {
+            "state_updates": [
+                {
+                    "hash": "hash-2",
+                    "success": False,
+                    "error": missing_batch_result_error(BATCH_KIND_UPSERT),
+                },
+            ],
+            "association_followups": [],
+        }
+
+        applied_hashes = sink._apply_batch_result(parsed)
+
+        assert applied_hashes == {"hash-2"}
+        sink.update_state.assert_called_once()
 
 
 class TestFlushDuplicateStates:

--- a/target_hubspot_v4/tests/test_batch.py
+++ b/target_hubspot_v4/tests/test_batch.py
@@ -7,9 +7,12 @@ from target_hubspot_v4.batch import (
     BATCH_KIND_UPDATE,
     BATCH_KIND_UPSERT,
     build_trace_id,
+    is_missing_batch_result_error,
     is_whole_batch_failure,
+    missing_batch_result_error,
     parse_batch_update_response,
     parse_batch_upsert_response,
+    summarize_batch_response,
 )
 from target_hubspot_v4.batch_sinks import CompaniesFallbackSink, ContactsFallbackSink
 
@@ -52,6 +55,28 @@ class TestBatchHelpers:
             "errors": [],
         }
         assert is_whole_batch_failure(response) is False
+
+    def test_missing_batch_result_error_uses_batch_kind(self):
+        assert missing_batch_result_error(BATCH_KIND_UPDATE) == "Missing result from batch update"
+        assert is_missing_batch_result_error(missing_batch_result_error(BATCH_KIND_UPSERT)) is True
+        assert is_missing_batch_result_error("Some other error") is False
+
+    def test_summarize_batch_response_counts_results_and_errors(self):
+        response = MagicMock(status_code=207)
+        response.json.return_value = {
+            "status": "COMPLETE",
+            "numErrors": 1,
+            "results": [{"objectWriteTraceId": "hash-1", "id": "1"}],
+            "errors": [{"message": "boom"}],
+        }
+        assert summarize_batch_response(response, 2) == {
+            "status_code": 207,
+            "inputs": 2,
+            "results": 1,
+            "errors": 1,
+            "num_errors": 1,
+            "completion_status": "COMPLETE",
+        }
 
     def test_parse_superseded_row_gets_success(self):
         response = MagicMock(status_code=207)
@@ -174,6 +199,51 @@ class TestBatchRouting:
         state_updates, _ = parse_batch_update_response(response, staged_records)
         assert state_updates[0]["success"] is True
         assert state_updates[0]["id"] == "123"
+
+    def test_update_response_marks_missing_result_for_fallback(self):
+        response = MagicMock(status_code=207)
+        response.json.return_value = {
+            "results": [{"objectWriteTraceId": "hash-1", "id": "123"}],
+            "errors": [],
+        }
+        staged_records = [
+            _staged("hash-1", properties={"name": "Acme"}, id="123", batch_kind=BATCH_KIND_UPDATE),
+            _staged("hash-2", properties={"name": "Beta"}, id="456", batch_kind=BATCH_KIND_UPDATE),
+        ]
+        state_updates, _ = parse_batch_update_response(response, staged_records)
+        missing = next(s for s in state_updates if s["hash"] == "hash-2")
+        assert missing["success"] is False
+        assert missing["error"] == missing_batch_result_error(BATCH_KIND_UPDATE)
+
+
+class TestMissingBatchResultFallback:
+    """Records omitted from HubSpot batch responses fall back to single writes."""
+
+    def test_missing_batch_result_state_is_not_applied(self):
+        sink = _make_sink(CompaniesFallbackSink, "companies")
+        sink.update_state = MagicMock()
+        sink.write_single_staged_record = MagicMock()
+
+        staged = _staged(
+            "hash-2",
+            properties={"name": "Beta", "id": "456"},
+            id="456",
+            batch_kind=BATCH_KIND_UPDATE,
+        )
+        parsed = {
+            "state_updates": [
+                {"hash": "hash-1", "success": True, "id": "123"},
+                {"hash": "hash-2", "success": False, "error": missing_batch_result_error(BATCH_KIND_UPDATE)},
+            ],
+            "association_followups": [],
+        }
+
+        applied_hashes = sink._apply_batch_result(parsed)
+
+        assert applied_hashes == {"hash-1"}
+        sink.update_state.assert_called_once()
+        unapplied = sink._unapplied_staged_records([staged], applied_hashes)
+        assert unapplied == [staged]
 
 
 class TestFlushDuplicateStates:


### PR DESCRIPTION
HubSpot batch/update can return 200 COMPLETE while omitting some inputs from `results` and `errors`. We reproduced this with stale post-merge ids: the write is not applied, but single PATCH on the stale id works.

The batch parser flags those rows as missing results. This change defers that outcome for batch/update only so unmapped rows fall back to single-record `FallbackSink` writes. Missing results on batch/upsert and batch/create still fail immediately. Real batch errors are unchanged.

- Add `should_fallback_missing_batch_result()` so only update missing outcomes defer state
- Log batch response summary after every batch POST
- Log `externalId`, HubSpot id, and hash before update fallback

## Changed files
- **batch.py**: `missing_batch_result_error()`, `should_fallback_missing_batch_result()`, `summarize_batch_response()`
- **batch_client.py**: update-only missing-result deferral and fallback
- **tests/test_batch.py**: helpers, parser gap, update fallback, upsert fail-through